### PR TITLE
Pass self into ListSqlQueryKeyBit

### DIFF
--- a/rest_framework_extensions/key_constructor/bits.py
+++ b/rest_framework_extensions/key_constructor/bits.py
@@ -164,10 +164,12 @@ class PaginationKeyBit(QueryParamsKeyBit):
 
 class ListSqlQueryKeyBit(KeyBitBase):
     def get_data(self, params, view_instance, view_method, request, args, kwargs):
-        return force_text(
-            view_instance.filter_queryset(view_instance.get_queryset()).query.__str__()
-        )
-
+        try:
+            return force_text(
+                view_instance.filter_queryset(view_instance.get_queryset(self)).query.__str__()
+            )
+        except ValueError:
+            return None
 
 class RetrieveSqlQueryKeyBit(KeyBitBase):
     def get_data(self, params, view_instance, view_method, request, args, kwargs):


### PR DESCRIPTION
- Wrapped ListSqlQueryKeyBit in try/except, added in self arg to get_queryset()

Thank you for a great library, @chibisov 
What do you think of this change? I cannot get the `ListSqlQueryKeyBit` class to work with out passing in `self` to the `get_queryset(self)` function
