### PR TITLE
don't cache response if calculated key is None

### DIFF
--- a/rest_framework_extensions/cache/decorators.py
+++ b/rest_framework_extensions/cache/decorators.py
@@ -48,12 +48,13 @@ class CacheResponse(object):
             args=args,
             kwargs=kwargs
         )
-        response = self.cache.get(key)
+        response = self.cache.get(key) if key is not None else None
         if not response:
             response = view_method(view_instance, request, *args, **kwargs)
             response = view_instance.finalize_response(request, response, *args, **kwargs)
             response.render()  # should be rendered, before picklining while storing to cache
-            self.cache.set(key, response, self.timeout)
+            if key is not None:
+                self.cache.set(key, response, self.timeout)
         return response
 
     def calculate_key(self,


### PR DESCRIPTION
Hi!

In some conditions I would like to avoid caching of responses. 
My first idea is that if the calculated key is None, just let's skip get/set actions.

What do you think about it?
