### PR TITLE
Cache key ignores query parameters

### DIFF
--- a/tests_app/tests/functional/cache/decorators/tests.py
+++ b/tests_app/tests/functional/cache/decorators/tests.py
@@ -18,3 +18,10 @@ class TestCacheResponseFunctionally(TestCase):
         resp_1 = self.client.get('/hello/')
         resp_2 = self.client.get('/hello/')
         self.assertEqual(resp_1.content, resp_2.content)
+
+    def test_cache_key_should_differ_with_query_param(self):
+        resp = self.client.get('/hello-param/?param=world')
+        self.assertEqual(force_text(resp.content), '"Hello world"')
+
+        resp = self.client.get('/hello-param/?param=everyone')
+        self.assertEqual(force_text(resp.content), '"Hello everyone"')

--- a/tests_app/tests/functional/cache/decorators/urls.py
+++ b/tests_app/tests/functional/cache/decorators/urls.py
@@ -1,9 +1,10 @@
 # -*- coding: utf-8 -*-
 from django.conf.urls import url
 
-from .views import HelloView
+from .views import HelloView, HelloParamView
 
 
 urlpatterns = [
     url(r'^hello/$', HelloView.as_view(), name='hello'),
+    url(r'^hello-param/$', HelloParamView.as_view(), name='hello-param'),
 ]

--- a/tests_app/tests/functional/cache/decorators/views.py
+++ b/tests_app/tests/functional/cache/decorators/views.py
@@ -9,3 +9,10 @@ class HelloView(views.APIView):
     @cache_response()
     def get(self, request, *args, **kwargs):
         return Response('Hello world')
+
+
+class HelloParamView(views.APIView):
+    @cache_response()
+    def get(self, request, *args, **kwargs):
+        param = request.GET.get("param")
+        return Response('Hello ' + param)


### PR DESCRIPTION
This is an incomplete pull request. It shows a bug with the view cache- it's ignoring the query parameters when it builds the cache key. I couldn't understand the code in the cache key constructor to actually implement a fix for this problem.
