### PR TITLE
QueryStringKeyBit catch all params and do not cache errors flag in CacheResponse

### DIFF
--- a/rest_framework_extensions/cache/decorators.py
+++ b/rest_framework_extensions/cache/decorators.py
@@ -9,7 +9,11 @@ from rest_framework_extensions.compat import six
 
 
 class CacheResponse(object):
-    def __init__(self, timeout=None, key_func=None, cache=None):
+    def __init__(self,
+                 timeout=None,
+                 key_func=None,
+                 cache=None,
+                 cache_errors=True):
         if timeout is None:
             self.timeout = extensions_api_settings.DEFAULT_CACHE_RESPONSE_TIMEOUT
         else:
@@ -19,6 +23,8 @@ class CacheResponse(object):
             self.key_func = extensions_api_settings.DEFAULT_CACHE_KEY_FUNC
         else:
             self.key_func = key_func
+
+        self.cache_errors = cache_errors
 
         self.cache = get_cache(cache or extensions_api_settings.DEFAULT_USE_CACHE)
 
@@ -53,9 +59,13 @@ class CacheResponse(object):
             response = view_method(view_instance, request, *args, **kwargs)
             response = view_instance.finalize_response(request, response, *args, **kwargs)
             response.render()  # should be rendered, before picklining while storing to cache
-            self.cache.set(key, response, self.timeout)
+
+            if not response.status_code >= 400 or self.cache_errors:
+                self.cache.set(key, response, self.timeout)
+
         if not hasattr(response, '_closable_objects'):
             response._closable_objects = []
+
         return response
 
     def calculate_key(self,

--- a/rest_framework_extensions/key_constructor/bits.py
+++ b/rest_framework_extensions/key_constructor/bits.py
@@ -32,6 +32,10 @@ class KeyBitDictBase(KeyBitBase):
             args=args,
             kwargs=kwargs
         )
+
+        if params == '*':
+            params = source_dict.keys()
+
         for key in params:
             value = source_dict.get(self.prepare_key_for_value_retrieving(key))
             if value is not None:

--- a/rest_framework_extensions/key_constructor/bits.py
+++ b/rest_framework_extensions/key_constructor/bits.py
@@ -24,22 +24,25 @@ class KeyBitDictBase(KeyBitBase):
 
     def get_data(self, params, view_instance, view_method, request, args, kwargs):
         data = {}
-        source_dict = self.get_source_dict(
-            params=params,
-            view_instance=view_instance,
-            view_method=view_method,
-            request=request,
-            args=args,
-            kwargs=kwargs
-        )
 
-        if params == '*':
-            params = source_dict.keys()
+        if params is not None:
+            source_dict = self.get_source_dict(
+                params=params,
+                view_instance=view_instance,
+                view_method=view_method,
+                request=request,
+                args=args,
+                kwargs=kwargs
+            )
 
-        for key in params:
-            value = source_dict.get(self.prepare_key_for_value_retrieving(key))
-            if value is not None:
-                data[self.prepare_key_for_value_assignment(key)] = force_text(value)
+            if params == '*':
+                params = source_dict.keys()
+
+            for key in params:
+                value = source_dict.get(self.prepare_key_for_value_retrieving(key))
+                if value is not None:
+                    data[self.prepare_key_for_value_assignment(key)] = force_text(value)
+
         return data
 
     def get_source_dict(self, params, view_instance, view_method, request, args, kwargs):
@@ -193,22 +196,14 @@ class RetrieveSqlQueryKeyBit(KeyBitBase):
 
 class ArgsKeyBit(KeyBitBase):
     def get_data(self, params, view_instance, view_method, request, args, kwargs):
-        if self.params is not None:
-            return [args[i] for i in self.params]
-        return args
+        if params == '*':
+            return args
+        elif params is not None:
+            return [args[i] for i in params]
+
+        return []
 
 
 class KwargsKeyBit(KeyBitDictBase):
-    def get_data(self, params, view_instance, view_method, request, args, kwargs):
-        # if no parameters specified, then get data for all kwargs
-        return super(KwargsKeyBit, self).get_data(
-            params=params or kwargs.keys(),
-            view_instance=view_instance,
-            view_method=view_method,
-            request=request,
-            args=args,
-            kwargs=kwargs
-        )
-
     def get_source_dict(self, params, view_instance, view_method, request, args, kwargs):
-        return kwargs
+        return [] if params is None else kwargs

--- a/tests_app/tests/unit/cache/decorators/tests.py
+++ b/tests_app/tests/unit/cache/decorators/tests.py
@@ -194,3 +194,43 @@ class CacheResponseTest(TestCase):
         cache_response_instance = cache_response()
         another_cache_response_instance = cache_response()
         self.assertTrue(cache_response_instance.cache is another_cache_response_instance.cache)
+
+    def test_dont_cache_response_with_error_if_cache_error_false(self):
+        cache_response_decorator = cache_response(cache_errors=False)
+        cache_response_decorator.cache.set = Mock()
+
+        class TestView(views.APIView):
+
+            def __init__(self, status, *args, **kwargs):
+                self.status = status
+                super(TestView, self).__init__(*args, **kwargs)
+
+            @cache_response_decorator
+            def get(self, request, *args, **kwargs):
+                return Response(status=self.status)
+
+        for status in (400, 500):
+            view_instance = TestView(status=status)
+            view_instance.dispatch(request=self.request)
+
+            self.assertFalse(cache_response_decorator.cache.set.called)
+
+    def test_cache_response_with_error_if_cache_error_true(self):
+        cache_response_decorator = cache_response()
+        cache_response_decorator.cache.set = Mock()
+
+        class TestView(views.APIView):
+
+            def __init__(self, status, *args, **kwargs):
+                self.status = status
+                super(TestView, self).__init__(*args, **kwargs)
+
+            @cache_response_decorator
+            def get(self, request, *args, **kwargs):
+                return Response(status=self.status)
+
+        for status in (400, 500):
+            view_instance = TestView(status=status)
+            view_instance.dispatch(request=self.request)
+
+            self.assertTrue(cache_response_decorator.cache.set.called)

--- a/tests_app/tests/unit/cache/decorators/tests.py
+++ b/tests_app/tests/unit/cache/decorators/tests.py
@@ -215,7 +215,7 @@ class CacheResponseTest(TestCase):
 
                 self.assertFalse(cache_response_decorator.cache.set.called)
 
-    def test_cache_response_with_error_if_cache_error_true(self):
+    def test_cache_response_with_error_by_default(self):
         cache_response_decorator = cache_response()
 
         class TestView(views.APIView):

--- a/tests_app/tests/unit/cache/decorators/tests.py
+++ b/tests_app/tests/unit/cache/decorators/tests.py
@@ -197,7 +197,6 @@ class CacheResponseTest(TestCase):
 
     def test_dont_cache_response_with_error_if_cache_error_false(self):
         cache_response_decorator = cache_response(cache_errors=False)
-        cache_response_decorator.cache.set = Mock()
 
         class TestView(views.APIView):
 
@@ -209,15 +208,15 @@ class CacheResponseTest(TestCase):
             def get(self, request, *args, **kwargs):
                 return Response(status=self.status)
 
-        for status in (400, 500):
-            view_instance = TestView(status=status)
-            view_instance.dispatch(request=self.request)
+        with patch.object(cache_response_decorator.cache, 'set'):
+            for status in (400, 500):
+                view_instance = TestView(status=status)
+                view_instance.dispatch(request=self.request)
 
-            self.assertFalse(cache_response_decorator.cache.set.called)
+                self.assertFalse(cache_response_decorator.cache.set.called)
 
     def test_cache_response_with_error_if_cache_error_true(self):
         cache_response_decorator = cache_response()
-        cache_response_decorator.cache.set = Mock()
 
         class TestView(views.APIView):
 
@@ -229,8 +228,9 @@ class CacheResponseTest(TestCase):
             def get(self, request, *args, **kwargs):
                 return Response(status=self.status)
 
-        for status in (400, 500):
-            view_instance = TestView(status=status)
-            view_instance.dispatch(request=self.request)
+        with patch.object(cache_response_decorator.cache, 'set'):
+            for status in (400, 500):
+                view_instance = TestView(status=status)
+                view_instance.dispatch(request=self.request)
 
-            self.assertTrue(cache_response_decorator.cache.set.called)
+                self.assertTrue(cache_response_decorator.cache.set.called)

--- a/tests_app/tests/unit/key_constructor/bits/tests.py
+++ b/tests_app/tests/unit/key_constructor/bits/tests.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 from mock import Mock
 
-import django
 from django.test import TestCase
 from django.utils.translation import override
 
@@ -458,13 +457,17 @@ class ArgsKeyBitTest(TestCase):
             'kwargs': None
         }
 
+    def test_with_no_args(self):
+        self.assertEqual(ArgsKeyBit().get_data(**self.kwargs), [])
+
     def test_with_all_args(self):
+        self.kwargs['params'] = '*'
         self.assertEqual(ArgsKeyBit().get_data(**self.kwargs), self.test_args)
 
     def test_with_specified_args(self):
-        test_arg_idx = [0, 2]
+        self.kwargs['params'] = test_arg_idx = [0, 2]
         expected_args = [self.test_args[i] for i in test_arg_idx]
-        self.assertEqual(ArgsKeyBit(test_arg_idx).get_data(**self.kwargs), expected_args)
+        self.assertEqual(ArgsKeyBit().get_data(**self.kwargs), expected_args)
 
 
 class KwargsKeyBitTest(TestCase):
@@ -483,7 +486,7 @@ class KwargsKeyBitTest(TestCase):
         }
 
     def test_resulting_dict_all_kwargs(self):
-        self.kwargs['params'] = self.test_kwargs.keys()
+        self.kwargs['params'] = '*'
         self.assertEqual(KwargsKeyBit().get_data(**self.kwargs), self.test_kwargs)
 
     def test_resulting_dict_specified_kwargs(self):
@@ -493,4 +496,4 @@ class KwargsKeyBitTest(TestCase):
         self.assertEqual(KwargsKeyBit().get_data(**self.kwargs), expected_kwargs)
 
     def test_resulting_dict_no_kwargs(self):
-        self.assertEqual(KwargsKeyBit().get_data(**self.kwargs), self.test_kwargs)
+        self.assertEqual(KwargsKeyBit().get_data(**self.kwargs), {})

--- a/tests_app/tests/unit/key_constructor/bits/tests.py
+++ b/tests_app/tests/unit/key_constructor/bits/tests.py
@@ -302,15 +302,18 @@ class RequestMetaKeyBitTest(TestCase):
 
 
 class QueryParamsKeyBitTest(TestCase):
-    def test_resulting_dict(self):
+    def setUp(self):
         self.kwargs = {
-            'params': ['part', 'callback', 'not_existing_param'],
+            'params': None,
             'view_instance': None,
             'view_method': None,
             'request': factory.get('?part=Londo&callback=jquery_callback'),
             'args': None,
             'kwargs': None
         }
+
+    def test_resulting_dict(self):
+        self.kwargs['params'] = ['part', 'callback', 'not_existing_param']
         expected = {
             'part': u'Londo',
             'callback': u'jquery_callback'
@@ -318,14 +321,7 @@ class QueryParamsKeyBitTest(TestCase):
         self.assertEqual(QueryParamsKeyBit().get_data(**self.kwargs), expected)
 
     def test_resulting_dict_all_params(self):
-        self.kwargs = {
-            'params': '*',
-            'view_instance': None,
-            'view_method': None,
-            'request': factory.get('?part=Londo&callback=jquery_callback'),
-            'args': None,
-            'kwargs': None
-        }
+        self.kwargs['params'] = '*'
         expected = {
             'part': u'Londo',
             'callback': u'jquery_callback'

--- a/tests_app/tests/unit/key_constructor/bits/tests.py
+++ b/tests_app/tests/unit/key_constructor/bits/tests.py
@@ -318,6 +318,21 @@ class QueryParamsKeyBitTest(TestCase):
         }
         self.assertEqual(QueryParamsKeyBit().get_data(**self.kwargs), expected)
 
+    def test_resulting_dict_all_params(self):
+        self.kwargs = {
+            'params': '*',
+            'view_instance': None,
+            'view_method': None,
+            'request': factory.get('?part=Londo&callback=jquery_callback'),
+            'args': None,
+            'kwargs': None
+        }
+        expected = {
+            'part': u'Londo',
+            'callback': u'jquery_callback'
+        }
+        self.assertEqual(QueryParamsKeyBit().get_data(**self.kwargs), expected)
+
 
 class PaginationKeyBitTest(TestCase):
     def setUp(self):


### PR DESCRIPTION
- QueryStringKeyBit can use all the query string parameters if `*` is passed
- new flag `cache_errors` in CacheResponse to not cache responses with 4xx or 5xx errors