### PR TITLE
Use force_text from compat

### DIFF
--- a/rest_framework_extensions/bulk_operations/mixins.py
+++ b/rest_framework_extensions/bulk_operations/mixins.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from django.utils.text import force_text
+from rest_framework_extensions.compat import force_text
 
 from rest_framework import status
 from rest_framework.response import Response

--- a/tests_app/tests/functional/cache/decorators/tests.py
+++ b/tests_app/tests/functional/cache/decorators/tests.py
@@ -2,7 +2,7 @@
 import datetime
 
 from django.test import TestCase
-from django.utils.encoding import force_text
+from rest_framework_extensions.compat import force_text
 
 from .urls import urlpatterns
 


### PR DESCRIPTION
Import 'force_text' from compat in every place. Should now work with Django 1.4. 

Similiar to this one: https://github.com/chibisov/drf-extensions/pull/64