### PR TITLE
Fail fast on unit tests and default params for key bits

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1358,10 +1358,13 @@ You can use `*` for retrieving all headers to key bit:
 *New in DRF-extensions development version*
 
 Retrieves data from the view's positional arguments.
-A list of position indices can be passed to indicate which arguments to use. For retrieving all arguments you can use `*`:
+A list of position indices can be passed to indicate which arguments to use. For retrieving all arguments you can use `*` which is also the default value:
 
     class MyKeyConstructor(KeyConstructor):
-        args = bits.ArgsKeyBit('*')  # will use all positional arguments
+        args = bits.ArgsKeyBit()  # will use all positional arguments
+
+    class MyKeyConstructor(KeyConstructor):
+        args = bits.ArgsKeyBit('*')  # same as above
 
     class MyKeyConstructor(KeyConstructor):
         args = bits.ArgsKeyBit([0, 2])
@@ -1371,10 +1374,13 @@ A list of position indices can be passed to indicate which arguments to use. For
 *New in DRF-extensions development version*
 
 Retrieves data from the views's keyword arguments.
-A list of keyword argument names can be passed to indicate which kwargs to use. For retrieving all kwargs you can use `*`:
+A list of keyword argument names can be passed to indicate which kwargs to use. For retrieving all kwargs you can use `*` which is also the default value:
 
     class MyKeyConstructor(KeyConstructor):
-        kwargs = bits.KwargsKeyBit('*')  # will use all keyword arguments
+        kwargs = bits.KwargsKeyBit()  # will use all keyword arguments
+
+    class MyKeyConstructor(KeyConstructor):
+        kwargs = bits.KwargsKeyBit('*')  # same as above
 
     class MyKeyConstructor(KeyConstructor):
         kwargs = bits.KwargsKeyBit(['user_id', 'city'])
@@ -1389,12 +1395,15 @@ Usage example:
             ['part', 'callback']
         )
 
-You can use `*` for retrieving all query params to key bit:
+You can use `*` for retrieving all query params to key bit which is also the default value:
 
 *New in DRF-extensions development version*
 
     class MyKeyConstructor(KeyConstructor):
-        all_query_params = bits.QueryParamsKeyBit('*')
+        all_query_params = bits.QueryParamsKeyBit('*')  # all qs parameters
+
+    class MyKeyConstructor(KeyConstructor):
+        all_query_params = bits.QueryParamsKeyBit()  # same as above
 
 #### PaginationKeyBit
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -196,14 +196,14 @@ User groups request:
     # Request
     GET /users/1/groups/ HTTP/1.1
     Accept: application/json
-    
+
     # Response
     HTTP/1.1 200 OK
     Content-Type: application/json; charset=UTF-8
 
     ['user groups']
 
-But what if you want to add custom controller to collection level? 
+But what if you want to add custom controller to collection level?
 
 DRF-extensions `action` and `link` decorators will help you with it. These decorators behaves exactly as default, but can receive additional parameter `is_for_list`:
 
@@ -240,9 +240,9 @@ Now you can post to collection level controller:
     POST /users/confirm_email/ HTTP/1.1
     Accept: application/json
     Content-Type: application/json
-    
+
     {"code": 123456}
-    
+
     # Response
     HTTP/1.1 200 OK
     Content-Type: application/json; charset=UTF-8
@@ -254,7 +254,7 @@ Or retrieve data from link collection level controller:
     # Request
     GET /users/surname_first_letters/ HTTP/1.1
     Accept: application/json
-    
+
     # Response
     HTTP/1.1 200 OK
     Content-Type: application/json; charset=UTF-8
@@ -803,7 +803,7 @@ with [DefaultKeyConstructor](#default-key-constructor).
 
 You can change cache key by providing `key_func` argument, which must be callable:
 
-    def calculate_cache_key(view_instance, view_method, 
+    def calculate_cache_key(view_instance, view_method,
                             request, args, kwargs):
         return '.'.join([
             len(args),
@@ -964,7 +964,7 @@ By the moment all goes fine - response returned and cached. Let's make the same 
 
 What is that? Oh, we forgot about format negotiations. We can add format to key bits:
 
-    def calculate_cache_key(view_instance, view_method, 
+    def calculate_cache_key(view_instance, view_method,
                             request, args, kwargs):
         return '.'.join([
             len(args),
@@ -1472,7 +1472,7 @@ You can define custom function for Etag value calculation with `etag_func` argum
 
     from rest_framework_extensions.etag.decorators import etag
 
-    def calculate_etag(view_instance, view_method, 
+    def calculate_etag(view_instance, view_method,
                        request, args, kwargs):
         return '.'.join([
             len(args),

--- a/rest_framework_extensions/key_constructor/bits.py
+++ b/rest_framework_extensions/key_constructor/bits.py
@@ -4,6 +4,12 @@ from django.db.models.query import EmptyQuerySet
 from rest_framework_extensions.compat import force_text
 
 
+class AllArgsMixin(object):
+
+    def __init__(self, params='*'):
+        super(AllArgsMixin, self).__init__(params)
+
+
 class KeyBitBase(object):
     def __init__(self, params=None):
         self.params = params
@@ -144,7 +150,7 @@ class RequestMetaKeyBit(KeyBitDictBase):
         return request.META
 
 
-class QueryParamsKeyBit(KeyBitDictBase):
+class QueryParamsKeyBit(AllArgsMixin, KeyBitDictBase):
     """
     Return example:
         {'part': 'Londo', 'callback': 'jquery_callback'}
@@ -194,7 +200,8 @@ class RetrieveSqlQueryKeyBit(KeyBitBase):
             return None
 
 
-class ArgsKeyBit(KeyBitBase):
+class ArgsKeyBit(AllArgsMixin, KeyBitBase):
+
     def get_data(self, params, view_instance, view_method, request, args, kwargs):
         if params == '*':
             return args
@@ -204,6 +211,7 @@ class ArgsKeyBit(KeyBitBase):
             return []
 
 
-class KwargsKeyBit(KeyBitDictBase):
+class KwargsKeyBit(AllArgsMixin, KeyBitDictBase):
+
     def get_source_dict(self, params, view_instance, view_method, request, args, kwargs):
         return kwargs

--- a/tests_app/tests/unit/key_constructor/bits/tests.py
+++ b/tests_app/tests/unit/key_constructor/bits/tests.py
@@ -328,6 +328,9 @@ class QueryParamsKeyBitTest(TestCase):
         }
         self.assertEqual(QueryParamsKeyBit().get_data(**self.kwargs), expected)
 
+    def test_default_params_is_all_args(self):
+        self.assertEqual(QueryParamsKeyBit().params, '*')
+
 
 class PaginationKeyBitTest(TestCase):
     def setUp(self):
@@ -465,6 +468,9 @@ class ArgsKeyBitTest(TestCase):
         expected_args = [self.test_args[i] for i in test_arg_idx]
         self.assertEqual(ArgsKeyBit().get_data(**self.kwargs), expected_args)
 
+    def test_default_params_is_all_args(self):
+        self.assertEqual(ArgsKeyBit().params, '*')
+
 
 class KwargsKeyBitTest(TestCase):
     def setUp(self):
@@ -493,3 +499,6 @@ class KwargsKeyBitTest(TestCase):
 
     def test_resulting_dict_no_kwargs(self):
         self.assertEqual(KwargsKeyBit().get_data(**self.kwargs), {})
+
+    def test_default_params_is_all_args(self):
+        self.assertEqual(KwargsKeyBit().params, '*')

--- a/tox.ini
+++ b/tox.ini
@@ -31,7 +31,7 @@ deps=
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/tests_app
 commands=
-    {envbindir}/django-admin.py test --settings=settings {posargs}
+    {envbindir}/django-admin.py test --settings=settings {posargs} --failfast
 
 [testenv:py27-drf2.3.5]
 deps=

--- a/tox.ini
+++ b/tox.ini
@@ -31,7 +31,7 @@ deps=
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/tests_app
 commands=
-    {envbindir}/django-admin.py test --settings=settings {posargs} --failfast
+    {envbindir}/django-admin.py test --settings=settings {posargs}
 
 [testenv:py27-drf2.3.5]
 deps=


### PR DESCRIPTION
- Stop unit tests upon first fail: there's no need to continue further in the tests
- Args, Kwargs and Query KeyBits have params set to '*' by default: having any of this key bits without '*' is meaningless