### PR TITLE
Respect parent lookup regex value (sending parent viewset to NestedRegistryItem)

### DIFF
--- a/rest_framework_extensions/routers.py
+++ b/rest_framework_extensions/routers.py
@@ -176,10 +176,12 @@ class NestedRegistryItem(object):
         prefix = '/'
         current_item = self
         i = len(parents_query_lookups) - 1
+        parent_lookup_value_regex = getattr(self.parent_viewset, 'lookup_value_regex', '[^/.]+')
         while current_item:
-            prefix = '{parent_prefix}/(?P<{parent_pk_kwarg_name}>[^/.]+)/{prefix}'.format(
+            prefix = '{parent_prefix}/(?P<{parent_pk_kwarg_name}>{parent_lookup_value_regex})/{prefix}'.format(
                 parent_prefix=current_item.parent_prefix,
                 parent_pk_kwarg_name=compose_parent_pk_kwarg_name(parents_query_lookups[i]),
+                parent_lookup_value_regex=parent_lookup_value_regex,
                 prefix=prefix
             )
             i -= 1

--- a/rest_framework_extensions/routers.py
+++ b/rest_framework_extensions/routers.py
@@ -147,10 +147,11 @@ class ExtendedActionLinkRouterMixin(object):
 
 
 class NestedRegistryItem(object):
-    def __init__(self, router, parent_prefix, parent_item=None):
+    def __init__(self, router, parent_prefix, parent_item=None, parent_viewset=None):
         self.router = router
         self.parent_prefix = parent_prefix
         self.parent_item = parent_item
+        self.parent_viewset = parent_viewset
 
     def register(self, prefix, viewset, base_name, parents_query_lookups):
         self.router._register(
@@ -161,7 +162,8 @@ class NestedRegistryItem(object):
         return NestedRegistryItem(
             router=self.router,
             parent_prefix=prefix,
-            parent_item=self
+            parent_item=self,
+            parent_viewset=viewset
         )
 
     def get_prefix(self, current_prefix, parents_query_lookups):
@@ -193,7 +195,8 @@ class NestedRouterMixin(object):
         self._register(*args, **kwargs)
         return NestedRegistryItem(
             router=self,
-            parent_prefix=self.registry[-1][0]
+            parent_prefix=self.registry[-1][0],
+            parent_viewset = self.registry[-1][1]
         )
 
     def get_api_root_view(self):


### PR DESCRIPTION
A try for this was made in #63 but it did not lead anywhere and this is really starting to become a problem for me so hopefully this is good enough :)

### Problem
Say that you have a user route (/users) and you do not want to expose the `id` value of the user, so you use the users email instead. Making a detailed route look like /users/frwickst@gmail.com. You test the route and notice that you get a 404 page. This is because the default lookup regex is `[^/.]+`, and this works fine for most routes, but not when there is a dot (.) in the route. And since dots are [valid in a url](http://stackoverflow.com/a/7555609) we this is a shame. The solution to this is to set your `lookup_filed` to 'email' and write your own [lookup_value_regex](http://www.django-rest-framework.org/api-guide/routers/#simplerouter) in your view. In this case we could set it to something fancy such as `[^@]+@[^@]+\.[^@/]+`. And voilà, the route now works.

The problem is that this regex value is **not** respected in the nested routers that are included in drf-extensions, instead the hard coded value of [`[^/.]+`](https://github.com/chibisov/drf-extensions/blob/f3f62290bd9970da5c1fac02275b87cfbb5ab73b/rest_framework_extensions/routers.py#L178) is used.

### Solution
By default we do not have access to the parents regex value as it is stored in the parents viewset, which we don't have access to either. This pull requests lets the viewset of the parent be passed to the ´NestedRegistryItem´ class, exposing all viewset functions and variables, including the regex. The regex is then used when creating the `get_parent_prefix()`, and falls back on the default value of `[^/.]+` if no regex is set.

### Caveat
There is a second thing here to keep in mind. If using custom lookup_field values in the view, one also needs to set the `lookup_url_kwarg` value when using nested router, in the example above it would be `lookup_url_kwarg = 'parent_lookup_email'`. This has to do with the way the `NestedViewSetMixin` is built, and can probably be fixes as well (just not in this pull request).