### PR TITLE
drf-extensions can use the DefaulView provided by since DRF version 2.4.3

### DIFF
--- a/rest_framework_extensions/routers.py
+++ b/rest_framework_extensions/routers.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
+from distutils.version import StrictVersion
 from django.core.exceptions import ImproperlyConfigured
 from django.core.urlresolvers import NoReverseMatch
 
+import rest_framework
 from rest_framework.routers import (
     DefaultRouter,
     SimpleRouter,
@@ -204,7 +206,10 @@ class NestedRouterMixin(object):
     def get_api_root_view(self):
         """
         Return a view to use as the API root.
+        Can be deleted once support of DRF < 2.4.3 is dropped.
         """
+        if StrictVersion(rest_framework.VERSION) >= StrictVersion('2.4.3'):
+            return super(NestedRouterMixin, self).get_api_root_view()
         api_root_dict = {}
         list_name = self.routes[0].name
         for prefix, viewset, basename in self.registry:


### PR DESCRIPTION
It allows a better integration with drf>3.0 that sligthly changes the `class APIRoot`

It is not my decision to remove support of drf 2.4.2 and older, but I think it should be the right thing to do here. Instead of my patch, we could remove the override of `get_api_root_view(self):` method instead.