### PR TITLE
fixing key constructor error when lookup_field!=lookup_url_kwarg

### DIFF
--- a/rest_framework_extensions/key_constructor/bits.py
+++ b/rest_framework_extensions/key_constructor/bits.py
@@ -197,7 +197,7 @@ class ListSqlQueryKeyBit(SqlQueryKeyBitBase):
 
 class RetrieveSqlQueryKeyBit(SqlQueryKeyBitBase):
     def get_data(self, params, view_instance, view_method, request, args, kwargs):
-        lookup_value = view_instance.kwargs[view_instance.lookup_field]
+        lookup_value = view_instance.kwargs[view_instance.lookup_url_kwarg]
         try:
             queryset = view_instance.filter_queryset(view_instance.get_queryset()).filter(
                 **{view_instance.lookup_field: lookup_value}


### PR DESCRIPTION
File "/home/vagrant/.virtualenvs/todoapp1/local/lib/python2.7/site-packages/rest_framework_extensions/key_constructor/bits.py", line 201, in get_data
lookup_value = view_instance.kwargs[view_instance.lookup_field]
KeyError: 'slug'

I believe view_instance.lookup_field should be replaced with: view_instance.lookup_url_kwarg.
