### PR TITLE
Pass response when rebuild_after_method_evaluation

### DIFF
--- a/rest_framework_extensions/etag/decorators.py
+++ b/rest_framework_extensions/etag/decorators.py
@@ -67,6 +67,7 @@ class ETAGProcessor(object):
                     view_instance=view_instance,
                     view_method=view_method,
                     request=request,
+                    response=response,
                     args=args,
                     kwargs=kwargs,
                 )

--- a/rest_framework_extensions/etag/decorators.py
+++ b/rest_framework_extensions/etag/decorators.py
@@ -49,6 +49,7 @@ class ETAGProcessor(object):
             view_instance=view_instance,
             view_method=view_method,
             request=request,
+            response=None,
             args=args,
             kwargs=kwargs,
         )
@@ -99,6 +100,7 @@ class ETAGProcessor(object):
                        view_instance,
                        view_method,
                        request,
+                       response,
                        args,
                        kwargs):
         if isinstance(self.etag_func, six.string_types):
@@ -109,6 +111,7 @@ class ETAGProcessor(object):
             view_instance=view_instance,
             view_method=view_method,
             request=request,
+            response=response,
             args=args,
             kwargs=kwargs,
         )


### PR DESCRIPTION
I use the `updated_at` timestamp off of the instance in order to generate my object etags – for that I need to be able to retrieve the instance, which I current do by simply calling `view_instance.get_object()` – however, this will use the `lookup_field` and kwarg passed to filter the queryset.

Which is fine. Unless that field changed in an the request, e.g. it was an update.

Being able to grab the instance, or at the very least the response.data in the event that the etag is being calculated after method evaluation would be super handy for this use case.
