### PR TITLE
Implementation of nested route framework using definitions in viewsets

### DIFF
--- a/rest_framework_extensions/fields.py
+++ b/rest_framework_extensions/fields.py
@@ -12,7 +12,7 @@ from rest_framework.relations import (
 )
 
 
-class ResourceUriField(HyperlinkedRelatedField):
+class ResourceUriField(HyperlinkedIdentityField):
     """
     Represents a hyperlinking uri that points to the detail view for that object.
 
@@ -30,12 +30,7 @@ class ResourceUriField(HyperlinkedRelatedField):
             "resource_uri": "http://localhost/v1/surveys/1/",
         }
     """
-    # todo: test me
-    read_only = True
-
-    def __init__(self, *args, **kwargs):
-        kwargs.setdefault('source', '*')
-        super(ResourceUriField, self).__init__(*args, **kwargs)
+    pass
 
 
 class NestedHyperlinkedRelatedField(HyperlinkedRelatedField):

--- a/rest_framework_extensions/fields.py
+++ b/rest_framework_extensions/fields.py
@@ -1,5 +1,15 @@
 # -*- coding: utf-8 -*-
-from rest_framework.relations import HyperlinkedRelatedField
+import functools
+from django.core.exceptions import ImproperlyConfigured
+from django.core.urlresolvers import NoReverseMatch
+from django.utils import six
+from django.utils.functional import cached_property
+from django.utils.module_loading import import_string
+from rest_framework.fields import get_attribute
+from rest_framework.relations import (
+    HyperlinkedRelatedField,
+    HyperlinkedIdentityField,
+)
 
 
 class ResourceUriField(HyperlinkedRelatedField):
@@ -26,3 +36,113 @@ class ResourceUriField(HyperlinkedRelatedField):
     def __init__(self, *args, **kwargs):
         kwargs.setdefault('source', '*')
         super(ResourceUriField, self).__init__(*args, **kwargs)
+
+
+class NestedHyperlinkedRelatedField(HyperlinkedRelatedField):
+    """
+    Handles HyperlinkedRelatedField with views that are nested.
+
+    Args:
+        view_name: Name of url rule used for reverse resolving
+        lookup_map: Item specifig mapping how to resolve url kwargs for named url conf.
+            If value is dict, it's used as is.
+            If value is string, it's resolved to class using django import_string.
+            If value is class (e.g. resolved from string above) lookup_map is constructed
+            member variables `lookup_field`, `lookup_url_kwarg` and `parent_lookup_map`.
+            If value is ommited, we try look for view from context and do above.
+            If no value is resolvable by above means, error is raised.
+
+    """
+    def __init__(self, lookup_map=None, **kwargs):
+        self.__lookup_map = lookup_map
+        assert 'lookup_field' not in kwargs, "Do not use `lookup_field` use `lookup_map` instead."
+        assert 'lookup_url_kwarg' not in kwargs, "Do not use `lookup_url_kwarg` use `lookup_map` instead."
+        # FIXME: implement update operations with related fields
+        kwargs['read_only'] = True
+        kwargs['queryset'] = None
+        super(NestedHyperlinkedRelatedField, self).__init__(**kwargs)
+
+    @cached_property
+    def _lookup_map(self):
+        lookup_map = self.__lookup_map or self.context.get('view', None)
+
+        assert lookup_map, (
+            "Field `{field}` of type `{type}` in `{serializer}` requires `lookup_map` "
+            "to be able to reverse `view_name`. \n"
+            "You can pass that as argument or it can be resolved from view parameters. "
+            "To resolve from view parameters, you need to pass view as argument "
+            "(via `lookup_map` as string or reference) or in context by adding "
+            "`context={{'view': view}}` when instantiating the serializer. ".format(
+                field=self.field_name,
+                type=self.__class__.__name__,
+                serializer=self.parent.__class__.__name__,
+            )
+        )
+
+        if isinstance(lookup_map, dict):
+            return lookup_map
+
+        if isinstance(lookup_map, six.string_types):
+            lookup_map = import_string(lookup_map)
+
+        lookup_field = getattr(lookup_map, 'lookup_field', None) or self.lookup_field
+        lookup_url_kw = getattr(lookup_map, 'lookup_url_kwarg', None) or lookup_field
+        parent_lookup_map = getattr(lookup_map, 'parent_lookup_map', {})
+        map_ = {lookup_url_kw: lookup_field}
+        map_.update(parent_lookup_map)
+        return map_
+
+    def get_url(self, obj, view_name, request, format):
+        # Unsaved objects will not have a valid URL.
+        if hasattr(obj, 'pk') and obj.pk in (None, ''):
+            return None
+
+        # get lookup map (will use properties lookup_map and view)
+        lookup_map = self._lookup_map
+        get = lambda x: x(obj) if callable(x) else get_attribute(obj, x.split('.'))
+
+        # build kwargs for reverse
+        try:
+            kwargs = dict((
+                (key, get(source)) for (key, source) in lookup_map.items()
+            ))
+        except (KeyError, AttributeError) as exc:
+            raise ValueError(
+                "Got {exc_type} when attempting to create url for field "
+                "`{field}` on serializer `{serializer}`. "
+                "The serializer field lookup_map might be configured incorrectly. "
+                "We used `{instance}` instance with lookup map `{lookup_map}`. "
+                "Original exception text was: {exc}.".format(
+                    exc_type=type(exc).__name__,
+                    field=self.field_name,
+                    serializer=self.parent.__class__.__name__,
+                    instance=obj.__class__.__name__,
+                    lookup_map=lookup_map,
+                    exc=exc,
+                )
+            )
+
+        try:
+            return self.reverse(self.view_name, kwargs=kwargs, request=request, format=format)
+        except NoReverseMatch as exc:
+            raise ImproperlyConfigured(
+                "Could not resolve URL for hyperlinked relationship in field "
+                "`{field}` on serializer `{serializer}`. "
+                "You may have failed to include the related model in your API, "
+                "or incorrectly configured `view_name` or `lookup_map` "
+                "attribute on this field. Original error: {exc}".format(
+                    field=self.field_name,
+                    view_name=self.view_name,
+                    serializer=self.parent.__class__.__name__,
+                    kwargs=kwargs,
+                    exc=exc,
+                )
+            )
+
+
+class NestedHyperlinkedIdentityField(NestedHyperlinkedRelatedField, HyperlinkedIdentityField):
+    """
+    Represents a nested hyperlinked resource itself.
+    Will get lookup_map from view class in serializer context
+    """
+    pass

--- a/rest_framework_extensions/routers.py
+++ b/rest_framework_extensions/routers.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
+import warnings
 from distutils.version import StrictVersion
 from django.core.exceptions import ImproperlyConfigured
 from django.core.urlresolvers import NoReverseMatch
+from django.utils.functional import cached_property
 
 import rest_framework
 from rest_framework.routers import (
@@ -13,8 +15,9 @@ from rest_framework.routers import (
 from rest_framework import views
 from rest_framework.reverse import reverse
 from rest_framework.response import Response
-from rest_framework_extensions.utils import flatten, compose_parent_pk_kwarg_name
+from rest_framework_extensions.utils import flatten
 from rest_framework_extensions.compat_drf import add_trailing_slash_if_needed
+from rest_framework_extensions.settings import extensions_api_settings
 
 
 class ExtendedActionLinkRouterMixin(object):
@@ -149,7 +152,7 @@ class ExtendedActionLinkRouterMixin(object):
         return dynamic_routes_instances
 
 
-class NestedRegistryItem(object):
+class LegacyNestedRegistryItem(object):
     def __init__(self, router, parent_prefix, parent_item=None, parent_viewset=None):
         self.router = router
         self.parent_prefix = parent_prefix
@@ -162,7 +165,7 @@ class NestedRegistryItem(object):
             viewset=viewset,
             base_name=base_name,
         )
-        return NestedRegistryItem(
+        return LegacyNestedRegistryItem(
             router=self.router,
             parent_prefix=prefix,
             parent_item=self,
@@ -180,6 +183,13 @@ class NestedRegistryItem(object):
         current_item = self
         i = len(parents_query_lookups) - 1
         parent_lookup_value_regex = getattr(self.parent_viewset, 'lookup_value_regex', '[^/.]+')
+
+        def compose_parent_pk_kwarg_name(value):
+            return '{0}{1}'.format(
+                extensions_api_settings.DEFAULT_PARENT_LOOKUP_KWARG_NAME_PREFIX,
+                value
+            )
+
         while current_item:
             prefix = '{parent_prefix}/(?P<{parent_pk_kwarg_name}>{parent_lookup_value_regex})/{prefix}'.format(
                 parent_prefix=current_item.parent_prefix,
@@ -192,16 +202,117 @@ class NestedRegistryItem(object):
         return prefix.strip('/')
 
 
+class NestedRegistryItem(object):
+    def __init__(self, router, prefix, viewset, extra_kwargs=None, parent_item=None):
+        self.router = router
+        self.prefix = prefix
+        self.viewset = viewset
+        self.extra_kwargs = extra_kwargs or {}
+        self.parent_item = parent_item
+        self.parent_pattern = parent_item.full_pattern if parent_item else ''
+
+        self.__register()
+
+    def __register(self):
+        # Check that same lookup_url_kwarg is not used twice in same nested chain
+        lookup_url_kwarg = self.lookup_url_kwarg
+        current = self.parent_item
+        while current:
+            assert current.lookup_url_kwarg != lookup_url_kwarg, (
+                "Viewsets %r and %r are nested and they have same "
+                "lookup_url_kwarg %r. Recheck values of lookup_url_kwarg "
+                "and lookup_field in those viewsets."
+                % (current.viewset, self.viewset, lookup_url_kwarg)
+            )
+            current = current.parent_item
+
+        prefix = '{0}/{1}'.format(self.parent_pattern, self.prefix).strip('/')
+        self.router._register(prefix, self.viewset, **self.extra_kwargs)
+
+    def register(self, prefix, viewset, base_name=None, parents_query_lookups=None, **kwargs):
+        # support passing as positional argument
+        kwargs['base_name'] = base_name
+
+        # support legacy interface.
+        if parents_query_lookups:
+            warnings.warn(
+                "Usage of `parents_query_lookups` for nested routes is "
+                "pending deprecation."
+                "Use `parent_lookup_map` in view class instead.",
+                PendingDeprecationWarning
+            )
+            def iter_from(cur):
+                while cur is not None:
+                    yield cur
+                    cur = cur.parent_item
+            prev_legacy_item = None
+            for item in reversed(list(iter_from(self))):
+                legacy_item = LegacyNestedRegistryItem(
+                     router=item.router,
+                     parent_prefix=item.prefix,
+                     parent_viewset=item.viewset,
+                     parent_item=prev_legacy_item,
+                )
+                prev_legacy_item = legacy_item
+            return legacy_item.register(
+                prefix=prefix,
+                viewset=viewset,
+                parents_query_lookups=parents_query_lookups,
+                **kwargs)
+
+        return NestedRegistryItem(
+            router=self.router,
+            prefix=prefix,
+            viewset=viewset,
+            extra_kwargs=kwargs,
+            parent_item=self,
+        )
+
+    @cached_property
+    def lookup_url_kwarg(self):
+        return (
+            getattr(self.viewset, 'lookup_url_kwarg', None) or
+            getattr(self.viewset, 'lookup_field', None) or
+            'ok'
+        )
+
+    @cached_property
+    def full_pattern(self):
+        lookup_value_regex = getattr(self.viewset, 'lookup_value_regex', '[^/.]+')
+        lookup_url_kwarg = self.lookup_url_kwarg
+
+        return '{parent_pattern}/{prefix}/(?P<{lookup_url_kwarg}>{lookup_value_regex})'.format(
+            parent_pattern=self.parent_pattern,
+            prefix=self.prefix,
+            lookup_url_kwarg=lookup_url_kwarg,
+            lookup_value_regex=lookup_value_regex,
+        ).strip('/')
+
+    def __enter__(self):
+        """
+        Support with statement
+
+        Example:
+            with api.register(r'example', ExampleViewSet) as example:
+                example.register(r'nested', NestedBiewSet)
+        """
+        return self
+
+    def __exit__(self, type, value, traceback):
+        pass
+
+
 class NestedRouterMixin(object):
     def _register(self, *args, **kwargs):
         return super(NestedRouterMixin, self).register(*args, **kwargs)
 
-    def register(self, *args, **kwargs):
-        self._register(*args, **kwargs)
+    def register(self, prefix, viewset, base_name=None, **kwargs):
+        kwargs['base_name'] = base_name
         return NestedRegistryItem(
             router=self,
-            parent_prefix=self.registry[-1][0],
-            parent_viewset=self.registry[-1][1]
+            prefix=prefix,
+            viewset=viewset,
+            extra_kwargs=kwargs
         )
 
     def get_api_root_view(self):

--- a/rest_framework_extensions/utils.py
+++ b/rest_framework_extensions/utils.py
@@ -11,7 +11,6 @@ from rest_framework_extensions.key_constructor.constructors import (
     DefaultObjectKeyConstructor,
     DefaultListKeyConstructor,
 )
-from rest_framework_extensions.settings import extensions_api_settings
 
 
 def get_rest_framework_features():
@@ -75,12 +74,6 @@ def get_model_opts_concrete_fields(opts):
         opts.concrete_fields = [f for f in opts.fields if f.column is not None]
     return opts.concrete_fields
 
-
-def compose_parent_pk_kwarg_name(value):
-    return '{0}{1}'.format(
-        extensions_api_settings.DEFAULT_PARENT_LOOKUP_KWARG_NAME_PREFIX,
-        value
-    )
 
 
 default_cache_key_func = DefaultKeyConstructor()

--- a/tests_app/tests/functional/routers/nested_router_mixin/tests.py
+++ b/tests_app/tests/functional/routers/nested_router_mixin/tests.py
@@ -26,24 +26,7 @@ from .views import (
 
 
 class NestedRouterMixinTestBehaviourBase(APITestCase):
-    router = ExtendedSimpleRouter()
-    # main routes
-    (
-        router.register(r'users', UserViewSet)
-              .register(r'groups', GroupViewSet, 'users-group', parents_query_lookups=['user_groups'])
-              .register(r'permissions', PermissionViewSet, 'users-groups-permission', parents_query_lookups=['group__user', 'group'])
-    )
-
-    # register on one depth
-    permissions_routes = router.register(r'permissions', PermissionViewSet)
-    permissions_routes.register(r'groups', GroupViewSet, 'permissions-group', parents_query_lookups=['permissions'])
-    permissions_routes.register(r'users', UserViewSet, 'permissions-user', parents_query_lookups=['groups__permissions'])
-
-    # simple routes
-    router.register(r'groups', GroupViewSet, 'group')
-    router.register(r'permissions', PermissionViewSet, 'permission')
-
-    urls = router.urls
+    urls = 'tests_app.tests.functional.routers.nested_router_mixin.urls_base'
 
     def setUp(self):
         self.users = {
@@ -337,19 +320,7 @@ class NestedRouterMixinTestBehaviour__actions_and_links(NestedRouterMixinTestBeh
 
 
 class NestedRouterMixinTestBehaviour__generic_relations(APITestCase):
-    router = ExtendedSimpleRouter()
-    # tasks route
-    (
-        router.register(r'tasks', TaskViewSet)
-              .register(r'comments', TaskCommentViewSet, 'tasks-comment', parents_query_lookups=['object_id'])
-    )
-    # books route
-    (
-        router.register(r'books', BookViewSet)
-              .register(r'comments', BookCommentViewSet, 'books-comment', parents_query_lookups=['object_id'])
-    )
-
-    urls = router.urls
+    urls = 'tests_app.tests.functional.routers.nested_router_mixin.urls_generic'
 
     def setUp(self):
         self.tasks = {
@@ -445,14 +416,7 @@ class NestedRouterMixinTestBehaviour__generic_relations(APITestCase):
 
 
 class NestedRouterMixinTestBehaviour__parent_viewset_lookup(APITestCase):
-    router = ExtendedSimpleRouter()
-    # main routes
-    (
-        router.register(r'users', UserViewSetWithEmailLookup)
-              .register(r'groups', GroupViewSet, 'users-group', parents_query_lookups=['user_groups__email'])
-    )
-
-    urls = router.urls
+    urls = 'tests_app.tests.functional.routers.nested_router_mixin.urls_behavior'
 
     def setUp(self):
         self.users = {
@@ -526,54 +490,3 @@ class NestedRouterMixinTestBehaviour__parent_viewset_lookup(APITestCase):
         response = self.client.get(url)
         msg = 'If user has no requested group it should return 404'
         self.assertEqual(response.status_code, 404, msg=msg)
-
-
-# class NestedRouterMixinTestBehaviour__generic_relations1(APITestCase):
-#     router = ExtendedSimpleRouter()
-#     # tasks route
-#     (
-#         router.register(r'tasks', TaskViewSet)
-#               .register(r'', TaskCommentViewSet, 'tasks-comment', parents_query_lookups=['object_id'])
-#     )
-#     # books route
-#     (
-#         router.register(r'books', BookViewSet)
-#               .register(r'', BookCommentViewSet, 'books-comment', parents_query_lookups=['object_id'])
-#     )
-#
-#     urls = router.urls
-#
-#     def setUp(self):
-#         self.tasks = {
-#             'one': TaskModel.objects.create(id=1, title='Task one'),
-#             'two': TaskModel.objects.create(id=2, title='Task two'),
-#         }
-#         self.books = {
-#             'one': BookModel.objects.create(id=1, title='Book one'),
-#             'two': BookModel.objects.create(id=2, title='Book two'),
-#         }
-#         self.comments = {
-#             'for_task_one': CommentModel.objects.create(
-#                 id=1,
-#                 content_object=self.tasks['one'],
-#                 text=u'Comment for task one'
-#             ),
-#             'for_task_two': CommentModel.objects.create(
-#                 id=2,
-#                 content_object=self.tasks['two'],
-#                 text=u'Comment for task two'
-#             ),
-#             'for_book_one': CommentModel.objects.create(
-#                 id=3,
-#                 content_object=self.books['one'],
-#                 text=u'Comment for book one'
-#             ),
-#             'for_book_two': CommentModel.objects.create(
-#                 id=4,
-#                 content_object=self.books['two'],
-#                 text=u'Comment for book two'
-#             ),
-#         }
-#
-#     def test_me(self):
-#         print 'hell'

--- a/tests_app/tests/functional/routers/nested_router_mixin/urls_base.py
+++ b/tests_app/tests/functional/routers/nested_router_mixin/urls_base.py
@@ -1,0 +1,30 @@
+from django.conf.urls import url, include
+from rest_framework_extensions.routers import ExtendedSimpleRouter
+
+from .views import (
+    UserViewSet,
+    GroupViewSet,
+    PermissionViewSet,
+)
+
+router = ExtendedSimpleRouter()
+
+# main routes
+(
+    router.register(r'users', UserViewSet)
+            .register(r'groups', GroupViewSet, 'users-group', parents_query_lookups=['user_groups'])
+            .register(r'permissions', PermissionViewSet, 'users-groups-permission', parents_query_lookups=['group__user', 'group'])
+)
+
+# register on one depth
+permissions_routes = router.register(r'permissions', PermissionViewSet)
+permissions_routes.register(r'groups', GroupViewSet, 'permissions-group', parents_query_lookups=['permissions'])
+permissions_routes.register(r'users', UserViewSet, 'permissions-user', parents_query_lookups=['groups__permissions'])
+
+# simple routes
+router.register(r'groups', GroupViewSet, 'group')
+router.register(r'permissions', PermissionViewSet, 'permission')
+
+urlpatterns = [
+    url(r'^', include(router.urls)),
+]

--- a/tests_app/tests/functional/routers/nested_router_mixin/urls_behavior.py
+++ b/tests_app/tests/functional/routers/nested_router_mixin/urls_behavior.py
@@ -1,0 +1,19 @@
+from django.conf.urls import url, include
+from rest_framework_extensions.routers import ExtendedSimpleRouter
+
+from .views import (
+    UserViewSetWithEmailLookup,
+    GroupViewSet,
+)
+
+router = ExtendedSimpleRouter()
+
+# main routesconfiguration
+(
+    router.register(r'users', UserViewSetWithEmailLookup)
+            .register(r'groups', GroupViewSet, 'users-group', parents_query_lookups=['user_groups__email'])
+)
+
+urlpatterns = [
+    url(r'^', include(router.urls)),
+]

--- a/tests_app/tests/functional/routers/nested_router_mixin/urls_generic.py
+++ b/tests_app/tests/functional/routers/nested_router_mixin/urls_generic.py
@@ -1,0 +1,26 @@
+from django.conf.urls import url, include
+from rest_framework_extensions.routers import ExtendedSimpleRouter
+
+from .views import (
+    TaskViewSet,
+    TaskCommentViewSet,
+    BookViewSet,
+    BookCommentViewSet
+)
+
+router = ExtendedSimpleRouter()
+
+# tasks route
+(
+    router.register(r'tasks', TaskViewSet)
+            .register(r'comments', TaskCommentViewSet, 'tasks-comment', parents_query_lookups=['object_id'])
+)
+# books route
+(
+    router.register(r'books', BookViewSet)
+            .register(r'comments', BookCommentViewSet, 'books-comment', parents_query_lookups=['object_id'])
+)
+
+urlpatterns = [
+    url(r'^', include(router.urls)),
+]

--- a/tests_app/tests/functional/routers/tests.py
+++ b/tests_app/tests/functional/routers/tests.py
@@ -20,9 +20,7 @@ class TestTrailingSlashIncluded(TestCase):
         lookup_allowed_symbols = get_lookup_allowed_symbols()
 
         for exp in ['^router-viewset/$',
-                    '^router-viewset/{0}/$'.format(lookup_allowed_symbols),
-                    '^router-viewset/list_controller/$',
-                    '^router-viewset/{0}/detail_controller/$'.format(lookup_allowed_symbols)]:
+                    '^router-viewset/{0}/$'.format(lookup_allowed_symbols)]:
             msg = 'Should find url pattern with regexp %s' % exp
             self.assertIsNotNone(get_url_pattern_by_regex_pattern(urls, exp), msg=msg)
 
@@ -39,8 +37,6 @@ class TestTrailingSlashRemoved(TestCase):
         )
 
         for exp in ['^router-viewset$',
-                    '^router-viewset/{0}$'.format(lookup_allowed_symbols),
-                    '^router-viewset/list_controller$',
-                    '^router-viewset/{0}/detail_controller$'.format(lookup_allowed_symbols)]:
+                    '^router-viewset/{0}$'.format(lookup_allowed_symbols)]:
             msg = 'Should find url pattern with regexp %s' % exp
             self.assertIsNotNone(get_url_pattern_by_regex_pattern(urls, exp), msg=msg)

--- a/tests_app/tests/unit/routers/nested_router_mixin/tests.py
+++ b/tests_app/tests/unit/routers/nested_router_mixin/tests.py
@@ -2,12 +2,18 @@
 from rest_framework_extensions.compat_drf import get_lookup_allowed_symbols
 from rest_framework_extensions.test import APITestCase
 from rest_framework_extensions.routers import ExtendedSimpleRouter
-from rest_framework_extensions.utils import compose_parent_pk_kwarg_name
+from rest_framework_extensions.settings import extensions_api_settings
 from .views import (
     UserViewSet,
     GroupViewSet,
     PermissionViewSet,
 )
+
+def compose_parent_pk_kwarg_name(value):
+    return '{0}{1}'.format(
+        extensions_api_settings.DEFAULT_PARENT_LOOKUP_KWARG_NAME_PREFIX,
+        value
+    )
 
 
 class NestedRouterMixinTest(APITestCase):

--- a/tests_app/tests/unit/routers/tests.py
+++ b/tests_app/tests/unit/routers/tests.py
@@ -161,36 +161,3 @@ class ExtendedDefaultRouterTest(TestCase):
             action1_list_route.name, u'{basename}-action-one-list')
         self.assertEqual(action2_detail_route.name, u'{basename}-action-two')
 
-    def test_with_default_controllers(self):
-        class BasicViewSet(viewsets.ViewSet):
-            @link()
-            def link(self, request, *args, **kwargs):
-                pass
-
-            @link()
-            def link_default(self, request, *args, **kwargs):
-                pass
-
-            @action()
-            def action(self, request, *args, **kwargs):
-                pass
-
-            @action()
-            def action_default(self, request, *args, **kwargs):
-                pass
-
-        routes = self.router.get_routes(BasicViewSet)
-        link_route = self.get_dynamic_route_by_def_name('link', routes)
-        link_default_route = self.get_dynamic_route_by_def_name('link_default', routes)
-        action_route = self.get_dynamic_route_by_def_name('action', routes)
-        action_default_route = self.get_dynamic_route_by_def_name(
-            'action_default', routes)
-
-        self.assertEqual(link_route.name, u'{basename}-link')
-        self.assertEqual(link_default_route.name, u'{basename}-link-default')
-        self.assertEqual(action_route.name, u'{basename}-action')
-        self.assertEqual(
-            action_default_route.name,
-            u'{basename}-action-default')
-        self.assertEqual(
-            action_default_route.name, u'{basename}-action-default')


### PR DESCRIPTION
I wasn't really happy that nested routes define url kwargs in register method. That split query filtering from definition of queryset. Also writing hyperlinkedidentityfield for these nested paths became overly complex. In addition the url kwargs differ in all nested routes and that makes reading lsit of api urls a bit too complex.

So, I created map in viewset that defines how url kwargs are used in filtering queryset and defining kwarg name only in parent viewset.

I created this PR as place for comments and to tell me if this approach is not what you think as good.

Currently this change would break backwards compatibility and should probably be implemented as new set of classes. Also there is no documentation or test changes yet. I just wanted to get your guys opinions on this matter first.

Here are few examples what this looks in our a-plus django application:

``` python
# routes
api = ExtendedDefaultRouter()

api.register(r'users',
             userprofile.api.views.UserViewSet,
             base_name='user')

with api.register(r'courses',
                  course.api.views.CourseViewSet,
                  base_name='course') as courses:
    courses.register(r'exercises',
                     course.api.views.CourseExercisesViewSet,
                     base_name='course-exercises')
    courses.register(r'students',
                     course.api.views.CourseStudentsViewSet,
                     base_name='course-students')
```

``` python
# viewsets
class CourseViewSet(ListSerializerMixin, viewsets.ReadOnlyModelViewSet):
    queryset = CourseInstance.objects.filter(visible_to_students=True)
    permission_classes = [permissions.IsAuthenticated]
    lookup_url_kwarg = 'course_id'
    listserializer_class = CourseBriefSerializer
    serializer_class = CourseSerializer

class CourseExercisesViewSet(NestedViewSetMixin, viewsets.ReadOnlyModelViewSet):
    permission_classes = [permissions.IsAuthenticated]
    lookup_url_kwarg = 'exercisemodule_id'
    serializer_class = CourseModuleSerializer
    queryset = CourseModule.objects.all()
    parent_lookup_map = {'course_id': 'course_instance.id'}

class CourseStudentsViewSet(NestedViewSetMixin, viewsets.ReadOnlyModelViewSet):
    permission_classes = [permissions.IsAuthenticated]
    lookup_url_kwarg = 'user_id'
    serializer_class = UserBriefSerialiser
    queryset = UserProfile.objects.all()
    parent_lookup_map = {'course_id': 'enrolled.id'}
```

``` python
# one of the serializers
class CourseSerializer(CourseBriefSerializer):
    exercises = NestedHyperlinkedIdentityField(view_name='api:course-exercises-list', format='html')
    students = NestedHyperlinkedIdentityField(view_name='api:course-students-list', format='html')

    class Meta(CourseBriefSerializer.Meta):
        fields = CourseBriefSerializer.Meta.fields + (
            'starting_time',
            'ending_time',
            'exercises',
            'students',
        )
```
