### PR TITLE
Started Django 1.11 support #187

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
   - "2.7"
 
 env:
+  - TOX_ENV=django.1.11
   - TOX_ENV=django.1.10
   - TOX_ENV=django.1.9
   - TOX_ENV=django.1.8.lts

--- a/rest_framework_extensions/etag/decorators.py
+++ b/rest_framework_extensions/etag/decorators.py
@@ -117,6 +117,7 @@ class ETAGProcessor(object):
 
     def is_if_none_match_failed(self, res_etag, etags, if_none_match):
         if res_etag and if_none_match:
+            etags = [etag.strip('"') for etag in etags]
             return res_etag in etags or '*' in etags
         else:
             return False

--- a/tox.ini
+++ b/tox.ini
@@ -33,7 +33,7 @@ deps=
 [testenv:django.1.11]
 deps=
     {[testenv]deps}
-    Django>=1.11
+    Django>=1.11,<2.0
     djangorestframework>=3.3.3
     django-guardian==1.4.4
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,6 @@
 [tox]
 envlist =
+    django.1.11
     django.1.10
     django.1.9
     django.1.8.lts
@@ -26,6 +27,14 @@ deps=
     {[testenv]deps}
     Django>=1.10,<1.11
     djangorestframework>=3.4.0
+    django-guardian==1.4.4
+
+
+[testenv:django.1.11]
+deps=
+    {[testenv]deps}
+    Django>=1.11
+    djangorestframework>=3.3.3
     django-guardian==1.4.4
 
 


### PR DESCRIPTION
This is just a really fix which fixes some of the Tox tests and a bug we where having where no responses where coming back as 304.
It looks like Django's `parse_tags()` ([django/utils/http.py](https://github.com/django/django/blob/550cb3a365dee4edfdd1563224d5304de2a57fda/django/utils/http.py#L222-L233)) was changed in a Django commit https://github.com/django/django/commit/4ef0e019b7dd3d2bf93b5c705b3b7df9cdb77561to because of issue [27083](https://code.djangoproject.com/ticket/27083) to return ETags with the quotes around. Instead of `123` it is now `"123"`.

I have just made it strip out the `"` characters which is probably a bad fix but it preserves backward compatibility and is nice and simple.

If you have a nicer suggestion let me know so we can use it in our project. Might help @auvipy with #187.