### PR TITLE
Parse rest-framework's version by using more tolerant functions

### DIFF
--- a/rest_framework_extensions/routers.py
+++ b/rest_framework_extensions/routers.py
@@ -1,12 +1,11 @@
 # -*- coding: utf-8 -*-
-from distutils.version import StrictVersion
+from distutils.version import LooseVersion
 from django.core.exceptions import ImproperlyConfigured
 try:
     from django.urls.resolvers import NoReverseMatch
 except ImportError:
     from django.core.urlresolvers import NoReverseMatch
 
-import rest_framework
 from rest_framework.routers import (
     DefaultRouter,
     SimpleRouter,
@@ -18,6 +17,8 @@ from rest_framework.reverse import reverse
 from rest_framework.response import Response
 from rest_framework_extensions.utils import flatten, compose_parent_pk_kwarg_name
 from rest_framework_extensions.compat_drf import add_trailing_slash_if_needed
+
+from .utils import get_rest_framework_version
 
 
 class ExtendedActionLinkRouterMixin(object):
@@ -212,9 +213,9 @@ class NestedRouterMixin(object):
         Return a view to use as the API root.
         Important to maintain compat with DRF 3.4.0
         """
-        if StrictVersion(rest_framework.VERSION) >= StrictVersion('3.4.0'):
+        if get_rest_framework_version() >= (3, 4, 0):
             return super(NestedRouterMixin, self).get_api_root_view(**kwargs)
-        if StrictVersion(rest_framework.VERSION) >= StrictVersion('2.4.3'):
+        if get_rest_framework_version() >= (2, 4, 3):
             return super(NestedRouterMixin, self).get_api_root_view()
         api_root_dict = {}
         list_name = self.routes[0].name

--- a/rest_framework_extensions/utils.py
+++ b/rest_framework_extensions/utils.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import itertools
 from functools import wraps
+from distutils.version import LooseVersion
 
 from django import VERSION as django_version
 
@@ -37,7 +38,7 @@ def get_django_features():
 
 
 def get_rest_framework_version():
-    return tuple(map(int, rest_framework.VERSION.split('.')))
+    return tuple(LooseVersion(rest_framework.VERSION).version)
 
 
 def flatten(list_of_lists):

--- a/tests_app/tests/functional/key_constructor/bits/views.py
+++ b/tests_app/tests/functional/key_constructor/bits/views.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
+import django_filters
 from rest_framework import viewsets
 from rest_framework_extensions.etag.mixins import ListETAGMixin, RetrieveETAGMixin
-from rest_framework.filters import DjangoFilterBackend
 
 from .models import KeyConstructorUserModel as UserModel
 from .serializers import UserModelSerializer
@@ -10,5 +10,5 @@ from .serializers import UserModelSerializer
 class UserModelViewSet(ListETAGMixin, RetrieveETAGMixin, viewsets.ModelViewSet):
     queryset = UserModel.objects.all()
     serializer_class = UserModelSerializer
-    filter_backends = (DjangoFilterBackend,)
+    filter_backends = (django_filters.rest_framework.DjangoFilterBackend,)
     filter_fields = ('property',)

--- a/tests_app/tests/functional/mixins/list_destroy_model_mixin/views.py
+++ b/tests_app/tests/functional/mixins/list_destroy_model_mixin/views.py
@@ -25,7 +25,7 @@ class CommentSerializer(serializers.ModelSerializer):
 class CommentViewSet(ListDestroyModelMixin, viewsets.ModelViewSet):
     queryset = Comment.objects.all()
     serializer_class = CommentSerializer
-    filter_backends = (filters.DjangoFilterBackend,)
+    filter_backends = (django_filters.rest_framework.DjangoFilterBackend,)
     filter_class = CommentFilter
 
 

--- a/tests_app/tests/functional/mixins/list_update_model_mixin/views.py
+++ b/tests_app/tests/functional/mixins/list_update_model_mixin/views.py
@@ -23,7 +23,7 @@ class CommentFilter(django_filters.FilterSet):
 class CommentViewSet(ListUpdateModelMixin, viewsets.ModelViewSet):
     queryset = Comment.objects.all()
     serializer_class = CommentSerializer
-    filter_backends = (filters.DjangoFilterBackend,)
+    filter_backends = (django_filters.rest_framework.DjangoFilterBackend,)
     filter_class = CommentFilter
 
 

--- a/tests_app/tests/unit/utils/tests.py
+++ b/tests_app/tests/unit/utils/tests.py
@@ -1,8 +1,19 @@
 # -*- coding: utf-8 -*-
+import contextlib
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 from django.test import TestCase
 
-from rest_framework_extensions.utils import prepare_header_name
+from rest_framework_extensions.utils import prepare_header_name, get_rest_framework_version
+
+
+@contextlib.contextmanager
+def parsed_version(version):
+    with mock.patch('rest_framework.VERSION', version):
+        yield get_rest_framework_version()
 
 
 class TestPrepareHeaderName(TestCase):
@@ -20,3 +31,13 @@ class TestPrepareHeaderName(TestCase):
     def test_adds_http_prefix(self):
         self.assertEqual(
             prepare_header_name('Accept-Language'), 'HTTP_ACCEPT_LANGUAGE')
+
+    def test_get_rest_framework_version_exotic_version(self):
+        """See <https://github.com/chibisov/drf-extensions/pull/198>"""
+        with parsed_version('1.2alphaSOMETHING') as version:
+            self.assertEqual(version, (1, 2, 'alpha', 'SOMETHING'))
+
+    def test_get_rest_framework_version_normal_version(self):
+        """See <https://github.com/chibisov/drf-extensions/pull/198>"""
+        with parsed_version('3.14.16') as version:
+            self.assertEqual(version, (3, 14, 16))

--- a/tox.ini
+++ b/tox.ini
@@ -58,6 +58,6 @@ deps=
 deps=
     {[testenv]deps}
     Django>=1.8,<1.9
-    djangorestframework>=3.3.2
+    djangorestframework>=3.3.2,<3.7
     django-guardian==1.4.4
 


### PR DESCRIPTION
We sometimes uses fixes that are in rest-framework's master, but not published yet. So me create a wheel `X.Y.PATCHpreCOMMITHASH` (something like `1.2.3pre8843d7f92416211de9ebb963ff4ce28125932878`) and somehow, `drf-extensions` actually chokes on it.

This uses `distutils` which is in the Python 2 and Python 3 standard library to parse the django-rest-framework's version.