### PR TITLE
eliminate Django 1.11 from tox.ini

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ python:
   - "2.7"
 
 env:
-  - TOX_ENV=django.1.11
   - TOX_ENV=django.1.10
   - TOX_ENV=django.1.9
   - TOX_ENV=django.1.8.lts

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,5 @@
 [tox]
 envlist =
-    django.1.11
     django.1.10
     django.1.9
     django.1.8.lts
@@ -27,14 +26,6 @@ deps=
     {[testenv]deps}
     Django>=1.10,<1.11
     djangorestframework>=3.4.0
-    django-guardian==1.4.4
-
-
-[testenv:django.1.11]
-deps=
-    {[testenv]deps}
-    Django>=1.11,<2.0
-    djangorestframework>=3.3.3
     django-guardian==1.4.4
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -41,7 +41,7 @@ deps=
 deps=
     {[testenv]deps}
     Django>=1.9,<1.10
-    djangorestframework>=3.3.3
+    djangorestframework>=3.3.3,<3.7
     django-guardian==1.4.4
 
 


### PR DESCRIPTION
Fix broken master build: https://github.com/chibisov/drf-extensions/issues/207

Django 1.9 support was dropped in DRF 3.7 as 1.9 is EOL:

https://github.com/encode/django-rest-framework/pull/5457