### PR TITLE
Use property is_authenticated instead for django 2.0 compatability

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1347,7 +1347,7 @@ class CityView(views.APIView):
     def head(self, request, *args, **kwargs):
         city = ''
         user = self.request.user
-        if user.is_authenticated() and user.city:
+        if user.is_authenticated and user.city:
             city = Response(user.city.name)
         if not city:
             city = get_city_by_ip(request.META['REMOTE_ADDR'])

--- a/docs/index.md
+++ b/docs/index.md
@@ -868,7 +868,7 @@ Of course we can use custom `calculate_cache_key` methods and reuse them for dif
         def head(self, request, *args, **kwargs):
             city = ''
             user = self.request.user
-            if user.is_authenticated() and user.city:
+            if user.is_authenticated and user.city:
                 city = Response(user.city.name)
             if not city:
                 city = get_city_by_ip(request.META['REMOTE_ADDR'])

--- a/rest_framework_extensions/key_constructor/bits.py
+++ b/rest_framework_extensions/key_constructor/bits.py
@@ -116,7 +116,7 @@ class UserKeyBit(KeyBitBase):
     """
 
     def get_data(self, params, view_instance, view_method, request, args, kwargs):
-        if hasattr(request, 'user') and request.user and request.user.is_authenticated():
+        if hasattr(request, 'user') and request.user and request.user.is_authenticated:
             return force_text(self._get_id_from_user(request.user))
         else:
             return u'anonymous'

--- a/tests_app/tests/unit/key_constructor/bits/tests.py
+++ b/tests_app/tests/unit/key_constructor/bits/tests.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from mock import Mock
+from mock import PropertyMock
 
 from django.test import TestCase
 from django.utils.translation import override
@@ -244,7 +245,8 @@ class UserKeyBitTest(TestCase):
         }
         self.user = Mock()
         self.user.id = 123
-        self.user.is_authenticated = Mock(return_value=False)
+        self.is_authenticated = PropertyMock(return_value=False)
+        type(self.user).is_authenticated = self.is_authenticated
 
     def test_without_user_in_request(self):
         expected = u'anonymous'
@@ -257,7 +259,7 @@ class UserKeyBitTest(TestCase):
 
     def test_with_autenticated_user(self):
         self.kwargs['request'].user = self.user
-        self.kwargs['request'].user.is_authenticated.return_value = True
+        self.is_authenticated.return_value = True
         expected = u'123'
         self.assertEqual(UserKeyBit().get_data(**self.kwargs), expected)
 


### PR DESCRIPTION
Django 2.0 removed support for calling is_authenticated as a function.
This PR changes all accesses to is_authenticated to use the property
version, which has been available since at least 1.11.

The last commit should probably be undone, but i'm unsure how to fix the actual root cause: ```This test was failing. Not sure whether this is the right fix, as i
couldn't quite figure out what was wrong from the issue linked in the
description.```