### PR TITLE
Fix test compatibility issue with DRF 3.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setup(
     url='http://github.com/chibisov/drf-extensions',
     download_url='https://pypi.python.org/pypi/drf-extensions/',
     license='BSD',
-    install_requires=['djangorestframework>=3.8.1'],
+    install_requires=['djangorestframework>=3.7.7'],
     description='Extensions for Django REST Framework',
     long_description='DRF-extensions is a collection of custom extensions for Django REST Framework',
     author='Gennady Chibisov',

--- a/tests_app/tests/functional/permissions/extended_django_object_permissions/views.py
+++ b/tests_app/tests/functional/permissions/extended_django_object_permissions/views.py
@@ -10,7 +10,9 @@ except ImportError:
 try:
     from rest_framework_extensions.permissions import ExtendedDjangoObjectPermissions
 except ImportError:
-    class ExtendedDjangoObjectPermissions:
+    from rest_framework.permissions import DjangoObjectPermissions
+
+    class ExtendedDjangoObjectPermissions(DjangoObjectPermissions):
         pass
 
 from .models import PermissionsComment

--- a/tox.ini
+++ b/tox.ini
@@ -1,14 +1,12 @@
 [tox]
 envlist =
-    py34-django{111,20}-drf{38,39}
-    py35-django{111,20}-drf{38,39}
-    py36-django{111,20}-drf{38,39}
-    py37-django{111,20}-drf{38,39}
+    py{34,35,36,37}-django{111,20}-drf{37,38,39}
 
 [testenv]
 deps=
     -rtests_app/requirements.txt
     django-guardian>=1.4.4
+    drf37: djangorestframework>=3.7,<3.8
     drf38: djangorestframework>=3.8.1,<3.9
     drf39: djangorestframework>=3.9.0,<3.10
     django111: Django>=1.11,<2.0


### PR DESCRIPTION
DRF >= 3.8 Breakings can cause real issues (see https://www.django-rest-framework.org/community/release-notes/#380). So a 3.7 compatibility which works with django 2.0 may be a good idea.