### PR TITLE
Fix broken DRF link

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -2204,7 +2204,7 @@ If you need to access the values of DRF-extensions API settings in your project,
 ### Release notes
 
 You can read about versioning, deprecation policy and upgrading from
-[Django REST framework documentation](http://django-rest-framework.org/topics/release-notes).
+[Django REST framework documentation](https://www.django-rest-framework.org/community/release-notes/).
 
 
 #### Development version


### PR DESCRIPTION
Other question,[ 0.4.0 has been released ](https://pypi.org/project/drf-extensions/) Sept 2018, but the GitHub hosted docs have not been updated: https://chibisov.github.io/drf-extensions/docs/#release-notes