### PR TITLE
Allow direct importing of ListDestroyModelMixin from rest_framework_extensions.mixins

### DIFF
--- a/rest_framework_extensions/mixins.py
+++ b/rest_framework_extensions/mixins.py
@@ -4,7 +4,7 @@
 
 from rest_framework_extensions.cache.mixins import CacheResponseMixin
 # from rest_framework_extensions.etag.mixins import ReadOnlyETAGMixin, ETAGMixin
-from rest_framework_extensions.bulk_operations.mixins import ListUpdateModelMixin
+from rest_framework_extensions.bulk_operations.mixins import ListUpdateModelMixin, ListDestroyModelMixin
 from rest_framework_extensions.settings import extensions_api_settings
 from django.http import Http404
 


### PR DESCRIPTION
added an import to rest_framework.mixins to allow direct importing of ListDestroyModelMixin
It appears that this is why ListUpdateModelMixin is imported into mixins (to facilitate direct importing), and the documentation also thinks that it is currently possible to directly import ListDestroyModelMixin. It isn't, this import makes it possible.