### PR TITLE
Fix #267, always restore headers via response[], this way even cache …

### DIFF
--- a/rest_framework_extensions/cache/decorators.py
+++ b/rest_framework_extensions/cache/decorators.py
@@ -96,7 +96,8 @@ class CacheResponse:
             # build smaller Django HttpResponse
             content, status, headers = response_triple
             response = HttpResponse(content=content, status=status)
-            response._headers = headers
+            for k, v in headers.values():
+                response[k] = v
 
         if not hasattr(response, '_closable_objects'):
             response._closable_objects = []


### PR DESCRIPTION
…serializers that don't support tuples will work.