### PR TITLE
delete rest_framework_extensions.test module usage in tests

### DIFF
--- a/tests_app/tests/functional/key_constructor/bits/tests.py
+++ b/tests_app/tests/functional/key_constructor/bits/tests.py
@@ -1,6 +1,6 @@
 from django.test import override_settings
 
-from rest_framework_extensions.test import APITestCase
+from rest_framework.test import APITestCase
 
 from .models import KeyConstructorUserProperty
 

--- a/tests_app/tests/functional/mixins/detail_serializer_mixin/tests.py
+++ b/tests_app/tests/functional/mixins/detail_serializer_mixin/tests.py
@@ -3,7 +3,7 @@ import datetime
 from django.test import TestCase, override_settings
 
 # todo: use from rest_framework when released
-from rest_framework_extensions.test import APIRequestFactory
+from rest_framework.test import APIRequestFactory
 from .models import Comment
 
 

--- a/tests_app/tests/functional/mixins/list_destroy_model_mixin/tests.py
+++ b/tests_app/tests/functional/mixins/list_destroy_model_mixin/tests.py
@@ -1,6 +1,6 @@
 from django.test import override_settings
 
-from rest_framework_extensions.test import APITestCase
+from rest_framework.test import APITestCase
 from rest_framework_extensions.settings import extensions_api_settings
 from rest_framework_extensions import utils
 

--- a/tests_app/tests/functional/mixins/list_update_model_mixin/tests.py
+++ b/tests_app/tests/functional/mixins/list_update_model_mixin/tests.py
@@ -5,7 +5,7 @@ import unittest
 import django
 from django.test import override_settings
 
-from rest_framework_extensions.test import APITestCase
+from rest_framework.test import APITestCase
 from rest_framework_extensions.settings import extensions_api_settings
 from rest_framework_extensions import utils
 

--- a/tests_app/tests/functional/permissions/extended_django_object_permissions/tests.py
+++ b/tests_app/tests/functional/permissions/extended_django_object_permissions/tests.py
@@ -5,7 +5,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.test import override_settings
 
 from rest_framework import status
-from rest_framework_extensions.test import APITestCase
+from rest_framework.test import APITestCase
 
 from tests_app.testutils import basic_auth_header
 from .models import PermissionsComment

--- a/tests_app/tests/functional/routers/extended_default_router/tests.py
+++ b/tests_app/tests/functional/routers/extended_default_router/tests.py
@@ -1,7 +1,7 @@
 from django.test import override_settings
 from django.urls import NoReverseMatch
 
-from rest_framework_extensions.test import APITestCase
+from rest_framework.test import APITestCase
 
 
 @override_settings(ROOT_URLCONF='tests_app.tests.functional.routers.extended_default_router.urls')

--- a/tests_app/tests/functional/routers/nested_router_mixin/tests.py
+++ b/tests_app/tests/functional/routers/nested_router_mixin/tests.py
@@ -1,6 +1,6 @@
 from django.test import override_settings
 
-from rest_framework_extensions.test import APITestCase
+from rest_framework.test import APITestCase
 
 from .models import (
     NestedRouterMixinUserModel as UserModel,

--- a/tests_app/tests/unit/_etag/decorators/tests.py
+++ b/tests_app/tests/unit/_etag/decorators/tests.py
@@ -8,7 +8,7 @@ from rest_framework.permissions import SAFE_METHODS
 from rest_framework_extensions.exceptions import PreconditionRequiredException
 
 from rest_framework_extensions.etag.decorators import (etag, api_etag)
-from rest_framework_extensions.test import APIRequestFactory
+from rest_framework.test import APIRequestFactory
 from rest_framework_extensions.utils import prepare_header_name
 
 from tests_app.testutils import (

--- a/tests_app/tests/unit/cache/decorators/tests.py
+++ b/tests_app/tests/unit/cache/decorators/tests.py
@@ -6,7 +6,7 @@ from rest_framework.response import Response
 
 from rest_framework_extensions.cache.decorators import cache_response
 from rest_framework_extensions.settings import extensions_api_settings
-from rest_framework_extensions.test import APIRequestFactory
+from rest_framework.test import APIRequestFactory
 from tests_app.testutils import override_extensions_api_settings
 
 factory = APIRequestFactory()

--- a/tests_app/tests/unit/key_constructor/bits/tests.py
+++ b/tests_app/tests/unit/key_constructor/bits/tests.py
@@ -6,7 +6,7 @@ from django.utils.translation import override
 
 from rest_framework import views
 from rest_framework.response import Response
-from rest_framework_extensions.test import APIRequestFactory
+from rest_framework.test import APIRequestFactory
 
 from rest_framework_extensions.key_constructor.bits import (
     KeyBitDictBase,

--- a/tests_app/tests/unit/key_constructor/constructor/tests.py
+++ b/tests_app/tests/unit/key_constructor/constructor/tests.py
@@ -11,7 +11,7 @@ from rest_framework_extensions.key_constructor.constructors import (
     KeyConstructor,
 )
 from rest_framework_extensions.utils import get_unique_method_id
-from rest_framework_extensions.test import APIRequestFactory
+from rest_framework.test import APIRequestFactory
 
 from tests_app.testutils import (
     override_extensions_api_settings,

--- a/tests_app/tests/unit/routers/nested_router_mixin/tests.py
+++ b/tests_app/tests/unit/routers/nested_router_mixin/tests.py
@@ -1,5 +1,5 @@
 from rest_framework.compat import get_regex_pattern
-from rest_framework_extensions.test import APITestCase
+from rest_framework.test import APITestCase
 from rest_framework_extensions.routers import ExtendedSimpleRouter
 from rest_framework_extensions.utils import compose_parent_pk_kwarg_name
 from .views import (


### PR DESCRIPTION
Forgot to clean project itself from usage of deprecated in #288 `rest_framework_extensions.test` module