### PR TITLE
Update EmptyResultSet import for django 3.1 compat

### DIFF
--- a/rest_framework_extensions/key_constructor/bits.py
+++ b/rest_framework_extensions/key_constructor/bits.py
@@ -1,6 +1,6 @@
 from django.utils.translation import get_language
 from django.db.models.query import EmptyQuerySet
-from django.db.models.sql.datastructures import EmptyResultSet
+from django.core.exceptions import EmptyResultSet
 
 from django.utils.encoding import force_str
 


### PR DESCRIPTION
https://docs.djangoproject.com/en/dev/releases/3.1/#id1