### PR TITLE
fix(PartialUpdateSerializerMixin): support nesting on same instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Full documentation for project is available at [http://chibisov.github.io/drf-ex
 
 * Tested for Python 3.6, 3.7 and 3.8
 * Tested for Django Rest Framework 3.9, 3.10 and 3.11
-* Tested for Django 1.11, 2.1, 2.2 and 3.0
+* Tested for Django 2.2 and 3.0
 * Tested for django-filter 2.1.0
 
 ## Installation:

--- a/rest_framework_extensions/serializers.py
+++ b/rest_framework_extensions/serializers.py
@@ -18,7 +18,15 @@ def get_fields_for_partial_update(opts, init_data, fields, init_files=None):
                 fields[field_name], 'source') or field_name
             if model_field_name in concrete_field_names:
                 update_fields.append(model_field_name)
-    return update_fields
+
+    # recurse on nested fields of same ('*') instance
+    for k, v in (init_data or {}).items():
+        if isinstance(v, dict) and k in fields and fields[k].source == '*':
+            recursive_fields = get_fields_for_partial_update(
+                opts, v, fields[k].fields.fields)
+            update_fields.extend(recursive_fields)
+
+    return sorted(set(update_fields))
 
 
 class PartialUpdateSerializerMixin:

--- a/tests_app/tests/unit/serializers/serializers.py
+++ b/tests_app/tests/unit/serializers/serializers.py
@@ -31,6 +31,31 @@ class CommentSerializer(drf_serializers.PartialUpdateSerializerMixin,
         )
 
 
+class CommentTextSerializer(drf_serializers.PartialUpdateSerializerMixin,
+                            serializers.ModelSerializer):
+
+    class Meta:
+        model = CommentModel
+        fields = (
+            'title',
+            'text'
+        )
+
+
+class CommentSerializerWithGroupedFields(CommentSerializer):
+    text_content = CommentTextSerializer(source='*')
+
+    class Meta(CommentSerializer.Meta):
+        fields = (
+            'id',
+            'user',
+            'users_liked',
+            'attachment',
+            'title_from_source',
+            'text_content'
+        )
+
+
 class CommentSerializerWithAllowedUserId(CommentSerializer):
     user_id = serializers.IntegerField()
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,5 @@
 [tox]
-envlist = py{36,37}-django{111}-drf39,
-          py{36,37}-django{21}-drf{39,310,311}
-          py{36,37,38}-django{22}-drf{39,310,311}
+envlist = py{36,37,38}-django{22}-drf{39,310,311}
           py{36,37,38}-django{30}-drf{310,311}
 
 
@@ -15,8 +13,6 @@ deps=
            djangorestframework-guardian
     drf311: djangorestframework>=3.11,<3.12
            djangorestframework-guardian
-    django111: Django>=1.11,<2.0
-    django21: Django>=2.1,<2.2
     django22: Django>=2.2,<3.0
     django30: Django>=3.0,<3.1
 setenv =


### PR DESCRIPTION
To fix https://github.com/chibisov/drf-extensions/issues/291.

Note that in order to have a failing test, I had to replace

```python
saved_object = serializer.save()
```
with

```python
serializer.save()
self.comment.refresh_from_db()
```
because the partial serializer actually puts the data into the instance, but merely does not save it due to `update_fields` being incomplete. So IMO we should refactor the other tests, too.