### PR TITLE
Make tests pass with DRF 3.12

### DIFF
--- a/tests_app/tests/unit/routers/nested_router_mixin/tests.py
+++ b/tests_app/tests/unit/routers/nested_router_mixin/tests.py
@@ -1,4 +1,3 @@
-from rest_framework.compat import get_regex_pattern
 from rest_framework.test import APITestCase
 from rest_framework_extensions.routers import ExtendedSimpleRouter
 from rest_framework_extensions.utils import compose_parent_pk_kwarg_name
@@ -10,6 +9,10 @@ from .views import (
     CustomRegexGroupViewSet,
     CustomRegexPermissionViewSet,
 )
+
+
+def get_regex_pattern(urlpattern):
+    return urlpattern.pattern.regex.pattern
 
 
 class NestedRouterMixinTest(APITestCase):

--- a/tests_app/testutils.py
+++ b/tests_app/testutils.py
@@ -2,7 +2,6 @@ import base64
 from mock import patch
 
 from rest_framework import HTTP_HEADER_ENCODING
-from rest_framework.compat import get_regex_pattern
 
 from rest_framework_extensions.key_constructor import bits
 from rest_framework_extensions.key_constructor.constructors import KeyConstructor
@@ -11,7 +10,7 @@ from rest_framework_extensions.key_constructor.constructors import KeyConstructo
 def get_url_pattern_by_regex_pattern(patterns, pattern_string):
     # todo: test me
     for pattern in patterns:
-        if get_regex_pattern(pattern) == pattern_string:
+        if pattern.pattern.regex.pattern == pattern_string:
             return pattern
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
-envlist = py{36,37,38}-django{22}-drf{39,310,311}
-          py{36,37,38}-django{30}-drf{310,311}
-          py{36,37,38}-django{31}-drf{311}
+envlist = py{36,37,38}-django{22}-drf{39,310,311,312}
+          py{36,37,38}-django{30}-drf{310,311,312}
+          py{36,37,38}-django{31}-drf{311,312}
 
 
 [testenv]
@@ -13,6 +13,8 @@ deps=
     drf310: djangorestframework>=3.10,<3.11
            djangorestframework-guardian
     drf311: djangorestframework>=3.11,<3.12
+           djangorestframework-guardian
+    drf312: djangorestframework>=3.12,<3.13
            djangorestframework-guardian
     django22: Django>=2.2,<3.0
     django30: Django>=3.0,<3.1


### PR DESCRIPTION
DRF dropped rest_framework.compat.get_regex_pattern as it dropped
support for Django < 2. As drf-extensions already does not support
Django < 2, just replay here the same change made in DRF.