### PR TITLE
django 3.2 compatibility : do not use _headers

### DIFF
--- a/rest_framework_extensions/cache/decorators.py
+++ b/rest_framework_extensions/cache/decorators.py
@@ -85,10 +85,15 @@ class CacheResponse:
             response.render()
 
             if not response.status_code >= 400 or self.cache_errors:
+                # django 3.0 has not .items() method, django 3.2 has not ._headers
+                if hasattr(response, '_headers'):
+                    headers = response._headers.copy()
+                else:
+                    headers = {k: (k, v) for k, v in response.items()}
                 response_triple = (
                     response.rendered_content,
                     response.status_code,
-                    response._headers.copy()
+                    headers
                 )
                 self.cache.set(key, response_triple, timeout)
         else:
@@ -97,7 +102,6 @@ class CacheResponse:
             response = HttpResponse(content=content, status=status)
             for k, v in headers.values():
                 response[k] = v
-
         if not hasattr(response, '_closable_objects'):
             response._closable_objects = []
 

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 envlist = py{36,37,38}-django{22}-drf{39,310,311,312}
           py{36,37,38}-django{30}-drf{310,311,312}
           py{36,37,38}-django{31}-drf{311,312}
-          py{36,37,38}-django{32}-drf{311,312}
+          py{36,37,38}-django{32}-drf{312}
 
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,7 @@
 envlist = py{36,37,38}-django{22}-drf{39,310,311,312}
           py{36,37,38}-django{30}-drf{310,311,312}
           py{36,37,38}-django{31}-drf{311,312}
+          py{36,37,38}-django{32}-drf{311,312}
 
 
 [testenv]
@@ -19,6 +20,7 @@ deps=
     django22: Django>=2.2,<3.0
     django30: Django>=3.0,<3.1
     django31: Django>=3.1,<3.2
+    django32: Django>=3.2
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/tests_app
 commands =


### PR DESCRIPTION
fix #306 

This PR removes the use of _headers when we are on django 3.2 and onwards but keeps it for 3.0 and 3.1. the `.items` method was introduced in django 3.0 and `_headers` attribute was removed in 3.2.
