### PR TITLE
Modified lookup_value to also use lookup_url_kwarg in RetrieveSqlQueryKeyBit 

### DIFF
--- a/rest_framework_extensions/key_constructor/bits.py
+++ b/rest_framework_extensions/key_constructor/bits.py
@@ -229,7 +229,8 @@ class ListSqlQueryKeyBit(SqlQueryKeyBitBase):
 
 class RetrieveSqlQueryKeyBit(SqlQueryKeyBitBase):
     def get_data(self, params, view_instance, view_method, request, args, kwargs):
-        lookup_value = view_instance.kwargs[view_instance.lookup_field]
+        lookup_value = view_instance.kwargs[
+            view_instance.lookup_url_kwarg or view_instance.lookup_field]
         try:
             queryset = view_instance.filter_queryset(view_instance.get_queryset()).filter(
                 **{view_instance.lookup_field: lookup_value}

--- a/tests_app/tests/unit/key_constructor/bits/tests.py
+++ b/tests_app/tests/unit/key_constructor/bits/tests.py
@@ -471,6 +471,7 @@ class RetrieveSqlQueryKeyBitTest(TestCase):
         }
         self.kwargs['view_instance'].kwargs = {'id': 123}
         self.kwargs['view_instance'].lookup_field = 'id'
+        self.kwargs['view_instance'].lookup_url_kwarg = None
         self.kwargs['view_instance'].get_queryset = Mock(return_value=BitTestModel.objects.all())
         self.kwargs['view_instance'].filter_queryset = lambda x: x.filter(is_active=True)
 
@@ -483,6 +484,22 @@ class RetrieveSqlQueryKeyBitTest(TestCase):
             expected = ('SELECT "unit_bittestmodel"."id", "unit_bittestmodel"."is_active" '
                         'FROM "unit_bittestmodel" '
                         'WHERE ("unit_bittestmodel"."is_active" = True AND "unit_bittestmodel"."id" = 123)')
+
+        response = RetrieveSqlQueryKeyBit().get_data(**self.kwargs)
+        self.assertEqual(response, expected)
+
+
+    def test_should_use_view__get_queryset__and_filter_it_with__filter_queryset__and_filter_by__lookup_field__and_get_kwarg_from_kwarg_lookup(self):
+        self.kwargs['view_instance'].kwargs = {'custom_kwarg_id': 456}
+        self.kwargs['view_instance'].lookup_url_kwarg = 'custom_kwarg_id'
+        if django.VERSION >= (3, 1):
+            expected = ('SELECT "unit_bittestmodel"."id", "unit_bittestmodel"."is_active" '
+                        'FROM "unit_bittestmodel" '
+                        'WHERE ("unit_bittestmodel"."is_active" AND "unit_bittestmodel"."id" = 456)')
+        else:
+            expected = ('SELECT "unit_bittestmodel"."id", "unit_bittestmodel"."is_active" '
+                        'FROM "unit_bittestmodel" '
+                        'WHERE ("unit_bittestmodel"."is_active" = True AND "unit_bittestmodel"."id" = 456)')
 
         response = RetrieveSqlQueryKeyBit().get_data(**self.kwargs)
         self.assertEqual(response, expected)


### PR DESCRIPTION
Fixes #107

( I think  PR #108  tried to fix this issue, but that implementation was incorrect. That PR can be closed as soon as this one is merged)  

The RetrieveSqlQueryKeyBit use to fetch the lookup_value only looking at lookup_field variable of the view. DRF allows [since 8 years](https://github.com/encode/django-rest-framework/commit/76672787cdba6a4ab8173b51fa099c910556889b) to supply for views a separate lookup_url_kwarg property, for when the name of the URL kwarg is different from the lookup_field name. DRF will use lookup_field to get the lookup_value from the URL unless lookup_url_kwarg is defined. This commit adds the same logic to the RetrieveSqlQueryKeyBit, allowing this bit to work when lookup_url_kwarg is used in DRF.

The RetrieveSqlQueryKeyBit unit tests was modified to work with this new setup a test was added to test the new functionality.