### PR TITLE
fix link to drf docs for viewsets

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -5,7 +5,7 @@ Source repository is available at [https://github.com/chibisov/drf-extensions](h
 
 ### Viewsets
 
-Extensions for [viewsets](https://www.django-rest-framework.org/api-guide/viewsets/s).
+Extensions for [viewsets](https://www.django-rest-framework.org/api-guide/viewsets/).
 
 #### DetailSerializerMixin
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,7 +5,7 @@ Source repository is available at [https://github.com/chibisov/drf-extensions](h
 
 ### Viewsets
 
-Extensions for [viewsets](http://django-rest-framework.org/api-guide/viewsets.html).
+Extensions for [viewsets](https://www.django-rest-framework.org/api-guide/viewsets/s).
 
 #### DetailSerializerMixin
 


### PR DESCRIPTION
current link leads to a 404 + not https by default.
