### PR TITLE
Using drf get_object_or_404 in filter_queryset_by_parents_lookups method

### DIFF
--- a/rest_framework_extensions/mixins.py
+++ b/rest_framework_extensions/mixins.py
@@ -1,8 +1,12 @@
+from rest_framework.generics import get_object_or_404
+
 from rest_framework_extensions.cache.mixins import CacheResponseMixin
 # from rest_framework_extensions.etag.mixins import ReadOnlyETAGMixin, ETAGMixin
-from rest_framework_extensions.bulk_operations.mixins import ListUpdateModelMixin, ListDestroyModelMixin
+from rest_framework_extensions.bulk_operations.mixins import (
+    ListUpdateModelMixin,
+    ListDestroyModelMixin
+)
 from rest_framework_extensions.settings import extensions_api_settings
-from django.http import Http404
 
 
 class DetailSerializerMixin:
@@ -57,13 +61,11 @@ class NestedViewSetMixin:
 
     def filter_queryset_by_parents_lookups(self, queryset):
         parents_query_dict = self.get_parents_query_dict()
+
         if parents_query_dict:
-            try:
-                return queryset.filter(**parents_query_dict)
-            except ValueError:
-                raise Http404
-        else:
-            return queryset
+            return get_object_or_404(queryset, **parents_query_dict)
+
+        return queryset
 
     def get_parents_query_dict(self):
         result = {}


### PR DESCRIPTION
The drf get_object_or_404 function handles django ValidationError and python TypeError and ValueError exceptions and raises a django Http404 exception. This way if the model uses some type for its primary key that needs to be validated (like an UUID) the exception will be handled correctly. E.g. the next url "foo/<uuid:pk>/", if the user access as "foo/other-format-that-is-not-an-uuid/", when the execution flow reaches filter_queryset_by_parents_lookups method an ValidationException will be produced and not handled correctly.