### PR TITLE
[WIP] feat: add parent permission check.

### DIFF
--- a/rest_framework_extensions/mixins.py
+++ b/rest_framework_extensions/mixins.py
@@ -1,22 +1,11 @@
 from rest_framework_extensions.cache.mixins import CacheResponseMixin
 from django.core.exceptions import ValidationError
 # from rest_framework_extensions.etag.mixins import ReadOnlyETAGMixin, ETAGMixin
+from django.http import Http404
 from rest_framework_extensions.bulk_operations.mixins import ListUpdateModelMixin, ListDestroyModelMixin
 from rest_framework_extensions.settings import extensions_api_settings
 from rest_framework import status, exceptions
-from django.http import Http404
-from django.shortcuts import get_object_or_404 as _get_object_or_404
-
-
-def get_object_or_404(queryset, *filter_args, **filter_kwargs):
-    """
-    Same as Django's standard shortcut, but make sure to also raise 404
-    if the filter_kwargs don't match the required types.
-    """
-    try:
-        return _get_object_or_404(queryset, *filter_args, **filter_kwargs)
-    except (TypeError, ValueError, ValidationError):
-        raise Http404
+from rest_framework.generics import get_object_or_404
 
 
 class DetailSerializerMixin:

--- a/rest_framework_extensions/mixins.py
+++ b/rest_framework_extensions/mixins.py
@@ -77,9 +77,9 @@ class NestedViewSetMixin:
         # TODO
         # 1. for model__submodel case.
         # 2. for generic relations case.
-        for parent_model_key, parent_model_filter_value in reversed(parents_query_dict.items()):
+        for parent_model_lookup_name, parent_model_lookup_value in reversed(parents_query_dict.items()):
             parent_model = current_model._meta.get_field(
-                parent_model_key).related_model
+                parent_model_lookup_name).related_model
             for parent_viewset_class in self.parent_viewsets:
                 parent_viewset = parent_viewset_class()
                 parent_viewset_model = getattr(
@@ -87,7 +87,7 @@ class NestedViewSetMixin:
                 if parent_viewset_model == parent_model:
                     parent_obj = get_object_or_404(
                         parent_viewset_model.objects.all(),
-                        **{parent_viewset.lookup_field: parent_model_filter_value}
+                        **{parent_viewset.lookup_field: parent_model_lookup_value}
                     )
                     parent_viewset.check_object_permissions(
                         request, parent_obj

--- a/rest_framework_extensions/mixins.py
+++ b/rest_framework_extensions/mixins.py
@@ -3,6 +3,7 @@ from django.core.exceptions import ValidationError
 # from rest_framework_extensions.etag.mixins import ReadOnlyETAGMixin, ETAGMixin
 from rest_framework_extensions.bulk_operations.mixins import ListUpdateModelMixin, ListDestroyModelMixin
 from rest_framework_extensions.settings import extensions_api_settings
+from rest_framework import status, exceptions
 from django.http import Http404
 from django.shortcuts import get_object_or_404 as _get_object_or_404
 
@@ -64,6 +65,29 @@ class PaginateByMaxMixin:
 
 class NestedViewSetMixin:
     parent_viewsets = set()
+
+    def check_ownership(self, serializer):
+        parent_query_dicts = self.get_parents_query_dict()
+        if parent_query_dicts:
+            parent_name, parent_value = list(parent_query_dicts.items())[-1]
+            items = serializer.validated_data
+            if not isinstance(items, list):
+                items = [items]
+            for item in items:
+                if item.get(parent_name, None) is None:
+                    raise exceptions.PermissionDenied(
+                        detail=f"You must specific '{parent_name}'", code=status.HTTP_403_FORBIDDEN)
+                if item.get(parent_name, None) != parent_value:
+                    raise exceptions.PermissionDenied(
+                        detail=f"You don't have permission to operate item that belone to '{parent_name}:{parent_value}'", code=status.HTTP_403_FORBIDDEN)
+
+    def perform_create(self, serializer):
+        self.check_ownership(serializer)
+        super().perform_create(serializer)
+
+    def perform_update(self, serializer):
+        self.check_ownership(serializer)
+        super().perform_update(serializer)
 
     def check_parent_object_permissions(self, request):
         # if parent viewset haven't init yet, then will raise no "kwargs" attribute error, but it doesn't matter, just ignore

--- a/rest_framework_extensions/routers.py
+++ b/rest_framework_extensions/routers.py
@@ -17,6 +17,7 @@ class NestedRegistryItem:
             viewset=viewset,
             basename=basename,
         )
+        viewset.parent_viewsets.add(self.parent_viewset)
         return NestedRegistryItem(
             router=self.router,
             parent_prefix=prefix,


### PR DESCRIPTION
FIX: #271 
FIX: #142 
FIX: #98 

## Notice

**This PR hasn't been completed yet, it already meets what I need so I just mark it as draft.**

It needs to think more about some special cases(i mentioned several in code comments.) and make some tests. 

It's welcome for everyone to update based on those codes. 

you can fork my repo and start a PR to [https://github.com/sobadgirl/drf-extensions](https://github.com/sobadgirl/drf-extensions)

OR

just copy those codes to your repo and start a PR to [https://github.com/chibisov/drf-extensions](https://github.com/chibisov/drf-extensions) directly. 


## Feature

Add permission chain check to check parent permissions. 

Think you have those URLs:
```
/api/users/1/
/api/users/1/houses/
/api/users/1/houses/1/
/api/users/1/houses/1/tables/
/api/users/1/houses/1/tables/1
```

## Before
If you didn't have permission on `/api/users/1`, then you can't visit it.
but you still can visit `/api/users/1/houses` and other subpaths of `/api/users/1/`. 

because when we visit `/api/users/1/houses/`, the request was sent to `HouseViewSet` directly, so DRF skipped checking the permission of `UserViewSet`. 


## After
when you visit `/api/users/1/houses/` will check permission of `UserViewSet.check_object_permissions`. 
when you visit `/api/users/1/houses/1/tables/` will check permissions of `UserViewSet.check_object_permissions` and `HouseViewSet.check_object_permissions`. 

so if you don't have permission to visit `/api/users/1/`, then you will be refuse to visit any subpath of `/api/users/1/`


