### PR TITLE
tests: Use basename='xxx' to set a unique basename

### DIFF
--- a/tests_app/tests/functional/mixins/detail_serializer_mixin/urls.py
+++ b/tests_app/tests/functional/mixins/detail_serializer_mixin/urls.py
@@ -10,9 +10,9 @@ from .views import (
 
 
 viewset_router = routers.DefaultRouter()
-viewset_router.register('comments', CommentViewSet)
-viewset_router.register('comments-2', CommentWithoutDetailSerializerClassViewSet)
-viewset_router.register('comments-3', CommentWithIdTwoViewSet)
-viewset_router.register('comments-4', CommentWithIdTwoAndIdOneForDetailViewSet)
-viewset_router.register('comments-5', CommentWithDetailSerializerAndNoArgsForGetQuerySetViewSet)
+viewset_router.register('comments', CommentViewSet, basename='alt1')
+viewset_router.register('comments-2', CommentWithoutDetailSerializerClassViewSet, basename='alt2')
+viewset_router.register('comments-3', CommentWithIdTwoViewSet, basename='alt3')
+viewset_router.register('comments-4', CommentWithIdTwoAndIdOneForDetailViewSet, basename='alt4')
+viewset_router.register('comments-5', CommentWithDetailSerializerAndNoArgsForGetQuerySetViewSet, basename='alt5')
 urlpatterns = viewset_router.urls

--- a/tests_app/tests/functional/mixins/detail_serializer_mixin/urls.py
+++ b/tests_app/tests/functional/mixins/detail_serializer_mixin/urls.py
@@ -15,4 +15,5 @@ viewset_router.register('comments-2', CommentWithoutDetailSerializerClassViewSet
 viewset_router.register('comments-3', CommentWithIdTwoViewSet, basename='alt3')
 viewset_router.register('comments-4', CommentWithIdTwoAndIdOneForDetailViewSet, basename='alt4')
 viewset_router.register('comments-5', CommentWithDetailSerializerAndNoArgsForGetQuerySetViewSet, basename='alt5')
+
 urlpatterns = viewset_router.urls

--- a/tests_app/tests/functional/mixins/list_destroy_model_mixin/urls.py
+++ b/tests_app/tests/functional/mixins/list_destroy_model_mixin/urls.py
@@ -4,6 +4,6 @@ from .views import CommentViewSet, CommentViewSetWithPermissions
 
 
 viewset_router = routers.DefaultRouter()
-viewset_router.register('comments', CommentViewSet)
-viewset_router.register('comments-with-permissions', CommentViewSetWithPermissions)
+viewset_router.register('comments', CommentViewSet, basename='alt1')
+viewset_router.register('comments-with-permissions', CommentViewSetWithPermissions, basename='alt2')
 urlpatterns = viewset_router.urls

--- a/tests_app/tests/functional/mixins/list_update_model_mixin/urls.py
+++ b/tests_app/tests/functional/mixins/list_update_model_mixin/urls.py
@@ -4,7 +4,7 @@ from .views import CommentViewSet, CommentViewSetWithPermissions, UserViewSet
 
 
 viewset_router = routers.DefaultRouter()
-viewset_router.register('comments', CommentViewSet)
-viewset_router.register('comments-with-permissions', CommentViewSetWithPermissions)
-viewset_router.register('users', UserViewSet)
+viewset_router.register('comments', CommentViewSet, basename='alt1')
+viewset_router.register('comments-with-permissions', CommentViewSetWithPermissions, basename='alt2')
+viewset_router.register('users', UserViewSet, basename='alt3')
 urlpatterns = viewset_router.urls

--- a/tests_app/tests/functional/mixins/paginate_by_max_mixin/urls.py
+++ b/tests_app/tests/functional/mixins/paginate_by_max_mixin/urls.py
@@ -8,7 +8,7 @@ from .views import (
 
 
 viewset_router = routers.DefaultRouter()
-viewset_router.register('comments', CommentViewSet)
-viewset_router.register('comments-without-paginate-by-param-attribute', CommentWithoutPaginateByParamViewSet)
-viewset_router.register('comments-without-max-paginate-by-attribute', CommentWithoutMaxPaginateByAttributeViewSet)
+viewset_router.register('comments', CommentViewSet, basename='1')
+viewset_router.register('comments-without-paginate-by-param-attribute', CommentWithoutPaginateByParamViewSet, basename='2')
+viewset_router.register('comments-without-max-paginate-by-attribute', CommentWithoutMaxPaginateByAttributeViewSet, basename='3')
 urlpatterns = viewset_router.urls

--- a/tests_app/tests/functional/permissions/extended_django_object_permissions/urls.py
+++ b/tests_app/tests/functional/permissions/extended_django_object_permissions/urls.py
@@ -9,11 +9,12 @@ from .views import (
 
 
 viewset_router = routers.DefaultRouter()
-viewset_router.register('comments', CommentViewSet)
-viewset_router.register('comments-permission-filter-backend', CommentViewSetPermissionFilterBackend)
-viewset_router.register('comments-without-hiding-forbidden-objects', CommentViewSetWithoutHidingForbiddenObjects)
+viewset_router.register('comments', CommentViewSet, basename='alt1')
+viewset_router.register('comments-permission-filter-backend', CommentViewSetPermissionFilterBackend, basename='alt2')
+viewset_router.register('comments-without-hiding-forbidden-objects', CommentViewSetWithoutHidingForbiddenObjects, basename='alt3')
 viewset_router.register(
     'comments-without-hiding-forbidden-objects-permission-filter-backend',
-    CommentViewSetWithoutHidingForbiddenObjectsPermissionFilterBackend
+    CommentViewSetWithoutHidingForbiddenObjectsPermissionFilterBackend,
+    basename='alt4'
 )
 urlpatterns = viewset_router.urls


### PR DESCRIPTION
Since DRF 3.15.0 a unique basename must be used due https://github.com/encode/django-rest-framework/pull/8438

Fixes #341