### PR TITLE
prefer new unittest.mock everywhere

### DIFF
--- a/tests_app/tests/unit/cache/decorators/tests.py
+++ b/tests_app/tests/unit/cache/decorators/tests.py
@@ -1,6 +1,9 @@
 from django.core.cache import caches
 from django.test import TestCase
-from mock import Mock, patch
+try:
+    from unittest.mock import Mock, patch
+except ImportError:
+    from mock import Mock, patch
 from rest_framework import views
 from rest_framework.response import Response
 

--- a/tests_app/tests/unit/key_constructor/bits/tests.py
+++ b/tests_app/tests/unit/key_constructor/bits/tests.py
@@ -1,5 +1,7 @@
-from mock import Mock
-from mock import PropertyMock
+try:
+    from unittest.mock import Mock, PropertyMock
+except ImportError:
+    from mock import Mock, PropertyMock
 
 import django
 from django.test import TestCase

--- a/tests_app/tests/unit/key_constructor/constructor/tests.py
+++ b/tests_app/tests/unit/key_constructor/constructor/tests.py
@@ -1,7 +1,10 @@
 from copy import deepcopy
 import hashlib
 import json
-from mock import Mock, patch
+try:
+    from unittest.mock import Mock, patch
+except ImportError:
+    from mock import Mock, patch
 
 from django.test import TestCase
 

--- a/tests_app/testutils.py
+++ b/tests_app/testutils.py
@@ -1,5 +1,8 @@
 import base64
-from mock import patch
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
 
 from rest_framework import HTTP_HEADER_ENCODING
 


### PR DESCRIPTION

This code pattern is laready used here:

[tests_app/tests/unit/utils/tests.py](https://github.com/chibisov/drf-extensions/blob/9df8f8962e25ef6382cb93f94e3318176e89c8ba/tests_app/tests/unit/utils/tests.py#L4)

----

https://github.com/testing-cabal/mock
mock is now part of the Python standard library, available as [unittest.mock](https://docs.python.org/dev/library/unittest.mock.html) in Python 3.3 onwards.