### PR TITLE
fixing bug where rendered response is evaluated twice,

### DIFF
--- a/rest_framework_extensions/cache/decorators.py
+++ b/rest_framework_extensions/cache/decorators.py
@@ -91,7 +91,7 @@ class CacheResponse:
                 else:
                     headers = {k: (k, v) for k, v in response.items()}
                 response_triple = (
-                    response.rendered_content,
+                    response.content,  # FIX: Use already-rendered content
                     response.status_code,
                     headers
                 )

--- a/rest_framework_extensions/cache/decorators.py
+++ b/rest_framework_extensions/cache/decorators.py
@@ -91,7 +91,7 @@ class CacheResponse:
                 else:
                     headers = {k: (k, v) for k, v in response.items()}
                 response_triple = (
-                    response.content,  # FIX: Use already-rendered content
+                    response.content,  # Use already-rendered content to avoid re-evaluating generators and other iterables
                     response.status_code,
                     headers
                 )


### PR DESCRIPTION
rendered_content and render both evaluate data. If data contains a generator it will be exhausted in the first render and won't make it into the cache 